### PR TITLE
Make time configurable on the Logs page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -325,9 +325,9 @@
       }
     },
     "@iml/qs-parsers": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@iml/qs-parsers/-/qs-parsers-4.0.1.tgz",
-      "integrity": "sha1-ovkw4HUn+Qzdb1FPvJ07zeitCBY=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@iml/qs-parsers/-/qs-parsers-4.1.0.tgz",
+      "integrity": "sha512-lvO3M05Jpn8smQlY8RINT2St82oprKVrk5zKSRklRLr8+E7d52nqxZZM1AbHUbK9IcemaDzJU3xysnhCkmjT2A==",
       "dev": true,
       "requires": {
         "@iml/fp": "8.0.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@iml/obj": "6.0.3",
     "@iml/parsely": "^4.0.1",
     "@iml/pdsh-parser": "^1.0.5",
-    "@iml/qs-parsers": "^4.0.1",
+    "@iml/qs-parsers": "^4.1.0",
     "angular": "1.5.11",
     "angular-animate": "1.5.11",
     "angular-mocks": "1.5.11",

--- a/source/iml/display-date.js
+++ b/source/iml/display-date.js
@@ -1,0 +1,50 @@
+// @flow
+
+//
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import Inferno from 'inferno';
+import { asViewer } from './as-viewer/as-viewer.js';
+import moment from 'moment';
+
+import type { TzPickerProps } from './tz-picker/tz-picker-reducer.js';
+
+const formatString = 'YYYY-MM-DD HH:mm:ss';
+
+const displayDate = (date: string, isUtc: boolean) => {
+  if (isUtc === true) return moment.utc(date).format(formatString);
+  else return moment(date).format(formatString);
+};
+
+export const DisplayDate = asViewer(
+  'tzPicker',
+  ({ tzPicker: { isUtc }, datetime }: { tzPicker: TzPickerProps, datetime: string }) => {
+    return (
+      <span class="date">
+        <span>{displayDate(datetime, isUtc)}</span>
+      </span>
+    );
+  }
+);
+
+export const displayDateComponent = {
+  bindings: {
+    tzPickerB: '<',
+    datetime: '<'
+  },
+  controller: function($element: HTMLElement[]) {
+    'ngInject';
+
+    const el = $element[0];
+
+    this.$onInit = () => {
+      Inferno.render(<DisplayDate viewer={this.tzPickerB} datetime={this.datetime} />, el);
+    };
+
+    this.$onDestroy = () => {
+      Inferno.render(null, el);
+    };
+  }
+};

--- a/source/iml/iml-module.js
+++ b/source/iml/iml-module.js
@@ -61,6 +61,7 @@ import storageComponent from './storage/storage-component.js';
 import storageDetailComponent from './storage/storage-detail-component.js';
 import addStorageComponent from './storage/add-storage-component.js';
 import { tzPickerComponent } from './tz-picker/tz-picker.js';
+import { displayDateComponent } from './display-date';
 
 import { loginState } from './login/login-states.js';
 
@@ -209,6 +210,7 @@ const imlModule = angular
   .component('addStorage', addStorageComponent)
   .component('storageDetail', storageDetailComponent)
   .component('tzPicker', tzPickerComponent)
+  .component('displayDate', displayDateComponent)
   .constant('STATE_SIZE', {
     SMALL: 'small',
     MEDIUM: 'medium',

--- a/source/iml/logs/log-query-component.js
+++ b/source/iml/logs/log-query-component.js
@@ -28,7 +28,10 @@ export function controller(
 
   qs$.map(x => x.qs).through(p);
 
-  $scope.$on('$destroy', () => qs$.destroy());
+  $scope.$on('$destroy', () => {
+    qs$.destroy();
+    this.tzPickerB.endBroadcast();
+  });
 
   Object.assign(this, {
     parserFormatter: {
@@ -41,17 +44,24 @@ export function controller(
 }
 
 export default {
+  bindings: {
+    tzPickerB: '<'
+  },
   controller,
   template: `
-<div class="row">
-  <div class="col-xs-12">
-    <parsely-box
-      on-submit="::$ctrl.onSubmit(qs)"
-      query="$ctrl.qs"
-      parser-formatter="::$ctrl.parserFormatter"
-      completer="::$ctrl.completer(value, cursorPosition)"
-    ></parsely-box>
+  <div class="container log container-full">  
+    <div class="row">
+      <div class="col-xs-12">
+        <parsely-box
+          on-submit="::$ctrl.onSubmit(qs)"
+          query="$ctrl.qs"
+          parser-formatter="::$ctrl.parserFormatter"
+          completer="::$ctrl.completer(value, cursorPosition)"
+        ></parsely-box>
+        <tz-picker stream="::$ctrl.tzPickerB"></tz-picker>
+      </div>
+    </div>
+    <ui-loader-view class="log-table"></ui-loader-view>
   </div>
-</div>
   `
 };

--- a/source/iml/logs/log-states.js
+++ b/source/iml/logs/log-states.js
@@ -20,6 +20,8 @@ import { addCurrentPage } from '../api-transforms.js';
 
 import { multiStream2 } from '../multi-stream.js';
 
+import { tzPickerB } from '../tz-picker/tz-picker-resolves.js';
+
 import type { qsFromLocationT } from '../qs-from-location/qs-from-location-module.js';
 
 import type { HighlandStreamT } from 'highland';
@@ -30,12 +32,8 @@ export const logState = {
     helpPage: 'Graphical_User_Interface_9_0.html#9.5',
     anonymousReadProtected: true
   },
-  template: `
-  <div class="container log container-full">
-    <log-query></log-query>
-    <ui-loader-view class="log-table"></ui-loader-view>
-  </div>
-  `
+  resolve: { tzPickerB },
+  component: 'logQuery'
 };
 
 export const logTableState = {
@@ -81,7 +79,8 @@ export const logTableState = {
           )
         )
       );
-    }
+    },
+    tzPickerB
   },
   component: 'logTable'
 };

--- a/source/iml/logs/log-table-component.js
+++ b/source/iml/logs/log-table-component.js
@@ -7,7 +7,10 @@
 
 function controller($location: Object) {
   'ngInject';
-  this.$onDestroy = () => this.log$.destroy();
+  this.$onDestroy = () => {
+    this.log$.destroy();
+    this.tzPickerB.endBroadcast();
+  };
 
   this.pageChanged = meta => {
     $location.search('offset', (meta.current_page - 1) * meta.limit);
@@ -16,7 +19,8 @@ function controller($location: Object) {
 
 export default {
   bindings: {
-    log$: '<'
+    log$: '<',
+    tzPickerB: '<'
   },
   controller,
   template: `
@@ -34,9 +38,7 @@ export default {
       <tbody>
         <tr ng-repeat="row in curr.val.objects track by row.resource_uri">
           <td>
-            <span>
-              {{ ::row.datetime| date:'yyyy-MM-dd HH:mm:ss' : 'UTC' }}
-            </span>
+            <display-date tz-picker-b="::$ctrl.tzPickerB" datetime="::row.datetime"></display-date>
           </td>
           <td restrict-to="{{ app.GROUPS.FS_ADMINS }}">
             <a ng-if="row.host_id != null" route-to="configure/server/{{ row.host_id }}">{{ ::row.fqdn }}</a>

--- a/source/iml/status/status-records-component.js
+++ b/source/iml/status/status-records-component.js
@@ -72,14 +72,14 @@ export default {
           <td class="hidden-xs">{{ row.record_type }}</td>
           <td as-viewer stream="::$ctrl.tzPickerB">
             <span as-value stream="::viewer">
-              <a ng-if="curr.val.isUtc === true" route-to="log/?datetime__gte={{ row.begin | date : 'yyyy-MM-dd HH:mm:ss' : 'UTC' }}">{{ row.begin | date : 'yyyy-MM-dd HH:mm:ss' : 'UTC' }}</a>
-              <a ng-if="curr.val.isUtc === false" route-to="log/?datetime__gte={{ row.begin | date : 'yyyy-MM-dd HH:mm:ss' : 'UTC' }}">{{ row.begin | date : 'yyyy-MM-dd HH:mm:ss' }}</a>
+              <a ng-if="curr.val.isUtc === true" route-to="log/?datetime__gte={{ row.begin | date : 'yyyy-MM-dd HH:mm:ssUTC' : 'UTC' }}">{{ row.begin | date : 'yyyy-MM-dd HH:mm:ss' : 'UTC' }}</a>
+              <a ng-if="curr.val.isUtc === false" route-to="log/?datetime__gte={{ row.begin | date : 'yyyy-MM-dd HH:mm:ssUTC' : 'UTC' }}">{{ row.begin | date : 'yyyy-MM-dd HH:mm:ss' }}</a>
             </span>
           </td>
           <td as-viewer stream="::$ctrl.tzPickerB">
             <span as-value stream="::viewer">
-              <a ng-if="!row.active && curr.val.isUtc === true" route-to="log/?datetime__lte={{ row.end | date : 'yyyy-MM-dd HH:mm:ss' : 'UTC' }}">{{ row.end | date : 'yyyy-MM-dd HH:mm:ss' : 'UTC' }}</a>
-              <a ng-if="!row.active && curr.val.isUtc === false" route-to="log/?datetime__lte={{ row.end | date : 'yyyy-MM-dd HH:mm:ss' : 'UTC' }}">{{ row.end | date : 'yyyy-MM-dd HH:mm:ss' }}</a>
+              <a ng-if="!row.active && curr.val.isUtc === true" route-to="log/?datetime__lte={{ row.end | date : 'yyyy-MM-dd HH:mm:ssUTC' : 'UTC' }}">{{ row.end | date : 'yyyy-MM-dd HH:mm:ss' : 'UTC' }}</a>
+              <a ng-if="!row.active && curr.val.isUtc === false" route-to="log/?datetime__lte={{ row.end | date : 'yyyy-MM-dd HH:mm:ssUTC' : 'UTC' }}">{{ row.end | date : 'yyyy-MM-dd HH:mm:ss' }}</a>
             </span>
           </td>
           <td>{{ row.message }}</td>

--- a/source/iml/tz-picker/tz-picker.js
+++ b/source/iml/tz-picker/tz-picker.js
@@ -1,5 +1,10 @@
 // @flow
 
+//
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
 import Inferno from 'inferno';
 import getStore from '../store/get-store.js';
 import { setTimeZoneToUtc, setTimeZoneToLocal } from './tz-picker-actions.js';

--- a/test/dom/iml/__snapshots__/display-date-test.js.snap
+++ b/test/dom/iml/__snapshots__/display-date-test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Display Date Component local time should create markup 1`] = `
+<span
+  class="date"
+>
+  <span>
+    2018-07-01 08:30:00
+  </span>
+</span>
+`;
+
+exports[`Display Date Component utc should create the markup 1`] = `
+<span
+  class="date"
+>
+  <span>
+    2018-07-01 12:30:00
+  </span>
+</span>
+`;

--- a/test/dom/iml/display-date-test.js
+++ b/test/dom/iml/display-date-test.js
@@ -1,0 +1,116 @@
+// @flow
+
+import { querySelector } from '../../../source/iml/dom-utils.js';
+import angular from '../../angular-mock-setup.js';
+import highland from 'highland';
+
+import Inferno from 'inferno';
+
+import type { HighlandStreamT } from 'highland';
+
+type UtcStream = HighlandStreamT<{ isUtc: boolean }>;
+interface MockMoment {
+  utc: Function;
+}
+
+describe('Display Date Component', () => {
+  let root: HTMLElement,
+    displayDate,
+    dateElement: HTMLElement,
+    $scope: $scope,
+    $compile,
+    template: string,
+    tzPicker$: UtcStream,
+    tzPickerB: () => UtcStream,
+    mockMoment: MockMoment,
+    mockMomentFormat,
+    mockMomentUtc,
+    mockMomentUtcFormat;
+
+  beforeEach(() => {
+    tzPicker$ = highland();
+    tzPickerB = jest.fn(() => tzPicker$);
+
+    mockMomentUtcFormat = jest.fn(() => '2018-07-01 12:30:00');
+    mockMomentUtc = jest.fn(() => ({
+      format: mockMomentUtcFormat
+    }));
+
+    mockMomentFormat = jest.fn(() => '2018-07-01 08:30:00');
+    mockMoment = (jest.fn(() => ({
+      format: mockMomentFormat
+    })): any);
+    mockMoment.utc = mockMomentUtc;
+
+    jest.mock('moment', () => mockMoment);
+    displayDate = require('../../../source/iml/display-date.js').displayDateComponent;
+  });
+
+  beforeEach(
+    angular.mock.module($compileProvider => {
+      $compileProvider.component('displayDate', displayDate);
+    })
+  );
+
+  beforeEach(
+    angular.mock.inject((_$compile_, $rootScope) => {
+      $scope = $rootScope.$new();
+      $scope.tzPickerB = tzPickerB;
+      $scope.datetime = '2018-07-01T12:30:00.0000+00:00';
+      $compile = _$compile_;
+      template = '<display-date tz-picker-b="tzPickerB" datetime="datetime"></tz-picker>';
+    })
+  );
+
+  beforeEach(() => {
+    tzPicker$.write({ isUtc: false });
+
+    root = $compile(template)($scope)[0];
+    querySelector(document, 'body').appendChild(root);
+    dateElement = querySelector(root, '.date');
+  });
+
+  afterEach(() => {
+    querySelector(document, 'body').removeChild(root);
+  });
+
+  describe('local time', () => {
+    it('should create markup', () => {
+      expect(dateElement).toMatchSnapshot();
+    });
+
+    it('should pass the ISO date to moment', () => {
+      expect(mockMoment).toHaveBeenCalledOnceWith('2018-07-01T12:30:00.0000+00:00');
+    });
+
+    it('should format the date', () => {
+      expect(mockMomentFormat).toHaveBeenCalledOnceWith('YYYY-MM-DD HH:mm:ss');
+    });
+  });
+
+  describe('utc', () => {
+    beforeEach(() => {
+      tzPicker$.write({ isUtc: true });
+    });
+
+    it('should create the markup', () => {
+      expect(dateElement).toMatchSnapshot();
+    });
+
+    it('should pass the ISO date to moment', () => {
+      expect(mockMomentUtc).toHaveBeenCalledOnceWith('2018-07-01T12:30:00.0000+00:00');
+    });
+
+    it('should format the date', () => {
+      expect(mockMomentUtcFormat).toHaveBeenCalledOnceWith('YYYY-MM-DD HH:mm:ss');
+    });
+  });
+
+  describe('removing', () => {
+    it('should no longer render the element', () => {
+      $scope.$destroy();
+      const removedDateDisplay = root.querySelector('.date');
+      expect(removedDateDisplay).toBeNull();
+    });
+  });
+});

--- a/test/dom/iml/message-substitution/log-table-component-test.js
+++ b/test/dom/iml/message-substitution/log-table-component-test.js
@@ -2,12 +2,26 @@ import logModule from '../../../../source/iml/logs/log-module.js';
 import highland from 'highland';
 import store from '../../../../source/iml/store/get-store.js';
 
+import { displayDateComponent } from '../../../../source/iml/display-date.js';
 import { setSession } from '../../../../source/iml/session/session-actions.js';
 
 import angular from '../../../angular-mock-setup.js';
 
 describe('log table component', () => {
-  let $scope, template, el, log$, table, dateField, fqdnLink, fqdnSpan, fqdnRestricted, tag, message, messageLink;
+  let $scope,
+    template,
+    el,
+    log$,
+    table,
+    dateField,
+    fqdnLink,
+    fqdnSpan,
+    fqdnRestricted,
+    tag,
+    message,
+    messageLink,
+    tzPickerB,
+    tzPicker$;
 
   beforeEach(() => {
     log$ = highland([
@@ -35,9 +49,19 @@ describe('log table component', () => {
         ]
       }
     ]);
+
+    tzPicker$ = highland([{ isUtc: true }]);
+    tzPickerB = jest.fn(() => tzPicker$);
+    tzPickerB.endBroadcast = jest.fn();
   });
 
   beforeEach(angular.mock.module(logModule));
+
+  beforeEach(
+    angular.mock.module($compileProvider => {
+      $compileProvider.component('displayDate', displayDateComponent);
+    })
+  );
 
   describe('with authorization', () => {
     beforeEach(
@@ -77,12 +101,13 @@ describe('log table component', () => {
 
         $scope = $rootScope.$new();
         $scope.log$ = log$;
-        template = '<log-table log$="::log$"></log-table>';
+        $scope.tzPickerB = tzPickerB;
+        template = '<log-table log$="::log$" tz-picker-b="::tzPickerB"></log-table>';
         el = $compile(template)($scope)[0];
         $scope.$digest();
 
         table = el.querySelector.bind(el, 'table');
-        dateField = el.querySelector.bind(el, 'table tr td:nth-of-type(1) span');
+        dateField = el.querySelector.bind(el, 'table tr td:nth-of-type(1) .date');
         fqdnLink = el.querySelector.bind(el, 'table tr td:nth-of-type(2) a');
         fqdnSpan = el.querySelector.bind(el, 'table tr td:nth-of-type(2) span');
         fqdnRestricted = el.querySelector.bind(el, 'table tr td:nth-of-type(3)');
@@ -163,12 +188,13 @@ describe('log table component', () => {
 
         $scope = $rootScope.$new();
         $scope.log$ = log$;
-        template = '<log-table log$="::log$"></log-table>';
+        $scope.tzPickerB = tzPickerB;
+        template = '<log-table log$="::log$" tz-picker-b="::tzPickerB"></log-table>';
         el = $compile(template)($scope)[0];
         $scope.$digest();
 
         table = el.querySelector.bind(el, 'table');
-        dateField = el.querySelector.bind(el, 'table tr td:nth-of-type(1) span');
+        dateField = el.querySelector.bind(el, 'table tr td:nth-of-type(1) .date');
         fqdnLink = el.querySelector.bind(el, 'table tr td:nth-of-type(2)');
         fqdnSpan = el.querySelector.bind(el, 'table tr td:nth-of-type(2) span');
         fqdnRestricted = el.querySelector.bind(el, 'table tr td:nth-of-type(3)');

--- a/test/spec/iml/logs/log-query-component-test.js
+++ b/test/spec/iml/logs/log-query-component-test.js
@@ -2,7 +2,7 @@ import highland from 'highland';
 import angular from '../../../angular-mock-setup.js';
 
 describe('log query component controller', () => {
-  let ctrl, $scope, $location, $stateParams, controller, qsStream, s;
+  let ctrl, $scope, $location, $stateParams, controller, qsStream, tzPickerB, s;
 
   beforeEach(() => {
     jest.mock('../../../../source/iml/logs/log-input-to-qs-parser.js', () => 'inputParser');
@@ -18,6 +18,10 @@ describe('log query component controller', () => {
     angular.mock.inject(($rootScope, propagateChange) => {
       $scope = $rootScope.$new();
 
+      tzPickerB = {
+        endBroadcast: jest.fn()
+      };
+
       $location = {
         search: jest.fn()
       };
@@ -30,7 +34,9 @@ describe('log query component controller', () => {
       jest.spyOn(s, 'destroy');
       qsStream = jest.fn(() => s);
 
-      ctrl = {};
+      ctrl = {
+        tzPickerB
+      };
 
       controller.bind(ctrl)($scope, $location, $stateParams, qsStream, propagateChange);
     })
@@ -67,9 +73,17 @@ describe('log query component controller', () => {
     expect($location.search).toHaveBeenCalledOnceWith('foo=bar');
   });
 
-  it('should destroy the route stream when the scope is destroyed', () => {
-    $scope.$destroy();
+  describe('on destroying the scope', () => {
+    beforeEach(() => {
+      $scope.$destroy();
+    });
 
-    expect(s.destroy).toHaveBeenCalledTimes(1);
+    it('should destroy the route stream', () => {
+      expect(s.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should end the broadcaster', () => {
+      expect(tzPickerB.endBroadcast).toHaveBeenCalledOnceWith();
+    });
   });
 });

--- a/test/spec/iml/logs/log-states-test.js
+++ b/test/spec/iml/logs/log-states-test.js
@@ -34,7 +34,10 @@ describe('status states', () => {
           helpPage: 'Graphical_User_Interface_9_0.html#9.5',
           anonymousReadProtected: true
         },
-        template: expect.any(String)
+        resolve: {
+          tzPickerB: expect.any(Function)
+        },
+        component: 'logQuery'
       });
     });
   });
@@ -65,7 +68,8 @@ describe('status states', () => {
           }
         },
         resolve: {
-          log$: expect.any(Function)
+          log$: expect.any(Function),
+          tzPickerB: expect.any(Function)
         },
         data: {
           kind: 'Logs',


### PR DESCRIPTION
The timestamps on the logs page are being displayed in UTC only. Give
the user the option of selecting local or UTC time.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>