### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM node:alpine
+FROM alpine
 WORKDIR /home/node/GUI
 COPY package*.json ./
 COPY source ./source
 COPY webpack.config.js ./
 COPY .babelrc ./
 COPY index.ejs .
-RUN npm install && \
+RUN apk add npm && \
+    npm install && \
     npm run postversion && \
     rm -rf source node_modules package*.json index.ejs webpack.config.js /root/.npm && \
     mv targetdir/* . && \
-    rm -rf targetdir
+    rm -rf targetdir && \
+    apk del npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:alpine
+WORKDIR /home/node/GUI
+COPY package*.json ./
+COPY source ./source
+COPY webpack.config.js ./
+COPY .babelrc ./
+COPY index.ejs .
+RUN npm install && \
+    npm run postversion && \
+    rm -rf source node_modules package*.json index.ejs webpack.config.js /root/.npm && \
+    mv targetdir/* . && \
+    rm -rf targetdir


### PR DESCRIPTION
Now that we are splitting out parts of the app into services the GUI
should be built into its own container. In this way, other services,
such as srcmap-reverse and nginx can communicate with the GUI container
to fufill their functionality.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>