### PR TITLE
Add as-viewers Higher Order Component

### DIFF
--- a/source/iml/as-viewer/as-viewer.js
+++ b/source/iml/as-viewer/as-viewer.js
@@ -5,6 +5,7 @@
 
 import type { Element } from "react";
 import type { HighlandStreamT } from "highland";
+import type { streamFnT } from "../broadcaster.js";
 
 import Inferno from "inferno";
 import Component from "inferno-component";
@@ -32,6 +33,38 @@ export const asViewer = <B: {}>(key: string, WrappedComponent: (b: B) => Element
       return <WrappedComponent {...this.props} {...this.state} />;
     }
   };
+
+export const asViewers = <B: {}>(keys: string[], WrappedComponent: (b: B) => Element<*>) => {
+  if (keys.length !== [...new Set(keys)].length) throw new Error("asViewers keys must be unique.");
+  else
+    return class AsViewers extends Component {
+      state: B;
+      viewers: streamFnT;
+      props: {
+        viewers: () => HighlandStreamT<B>
+      };
+      componentWillMount() {
+        this.viewers = this.props.viewers;
+
+        this.viewers.forEach(viewer => {
+          viewer.each((data: Object) => {
+            const key = keys.find(key => data[key] != null);
+
+            if (key)
+              this.setState({
+                [key]: data[key]
+              });
+          });
+        });
+      }
+      componentWillUnmount() {
+        this.viewers.forEach(viewer => viewer.destroy());
+      }
+      render() {
+        return <WrappedComponent {...this.props} {...this.state} />;
+      }
+    };
+};
 
 export default () => {
   return {

--- a/source/iml/as-viewer/as-viewer.js
+++ b/source/iml/as-viewer/as-viewer.js
@@ -34,18 +34,23 @@ export const asViewer = <B: {}>(key: string, WrappedComponent: (b: B) => Element
     }
   };
 
-export const asViewers = <B: {}>(WrappedComponent: (b: B) => Element<*>) =>
+export const asViewers = WrappedComponent =>
   class AsViewers extends Component {
     state: B;
     viewers: streamFnT;
     props: {
-      viewers: () => HighlandStreamT<B>
+      viewers: { string: Function },
+      transforms: { string: Function }
     };
     componentWillMount() {
-      this.viewers = this.props.viewers;
+      this.viewers = [];
 
-      Object.entries(this.viewers).forEach(([key, stream]) => {
-        stream.each((data: Object) => {
+      Object.entries(this.props.viewers).forEach(([key, viewer]) => {
+        const stream = viewer();
+        const transform = (this.props.transforms && this.props.transforms[key]) || (s => s);
+
+        this.viewers.push(stream);
+        stream.through(transform).each((data: Object) => {
           this.setState({
             [key]: data
           });

--- a/test/dom/iml/as-viewer/__snapshots__/as-viewer-test.js.snap
+++ b/test/dom/iml/as-viewer/__snapshots__/as-viewer-test.js.snap
@@ -18,7 +18,7 @@ exports[`as viewers with proper args should match the snapshot 1`] = `
     <div
       id="key2"
     >
-      val2
+      dewey!
     </div>
     <div
       id="key3"

--- a/test/dom/iml/as-viewer/__snapshots__/as-viewer-test.js.snap
+++ b/test/dom/iml/as-viewer/__snapshots__/as-viewer-test.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`as viewers with proper args should match the snapshot 1`] = `
+<div>
+  <div
+    id="multiple-viewers-component"
+  >
+    <h1
+      id="name"
+    >
+      test-component
+    </h1>
+    <div
+      id="key1"
+    >
+      val1
+    </div>
+    <div
+      id="key2"
+    >
+      val2
+    </div>
+    <div
+      id="key3"
+    >
+      val3
+    </div>
+  </div>
+</div>
+`;

--- a/test/dom/iml/as-viewer/as-viewer-test.js
+++ b/test/dom/iml/as-viewer/as-viewer-test.js
@@ -187,20 +187,22 @@ describe("as viewer", () => {
   });
 });
 
+const deweyTransform = s => s.map(x => ({ ...x, viewer2: { key2: "dewey!" } }));
 describe("as viewers", () => {
   let root, viewer1B, viewer1V, viewer2B, viewer2V, viewer3B, viewer3V, MultipleViewersComponent;
 
   describe("with proper args", () => {
     beforeEach(() => {
-      viewer1B = broadcaster(highland([{ viewer1: { key1: "val1" } }]));
-      viewer1V = viewer1B();
+      viewer1V = broadcaster(highland([{ viewer1: { key1: "val1" } }]))();
       jest.spyOn(viewer1V, "destroy");
-      viewer2B = broadcaster(highland([{ viewer2: { key2: "val2" } }]));
-      viewer2V = viewer2B();
+      viewer2V = broadcaster(highland([{ viewer2: { key2: "val2" } }]))();
       jest.spyOn(viewer2V, "destroy");
-      viewer3B = broadcaster(highland([{ viewer3: { key3: "val3" } }]));
-      viewer3V = viewer3B();
+      viewer3V = broadcaster(highland([{ viewer3: { key3: "val3" } }]))();
       jest.spyOn(viewer3V, "destroy");
+
+      viewer1B = jest.fn(() => viewer1V);
+      viewer2B = jest.fn(() => viewer2V);
+      viewer3B = jest.fn(() => viewer3V);
 
       MultipleViewersComponent = asViewers(
         ({
@@ -229,7 +231,8 @@ describe("as viewers", () => {
       root = document.createElement("div");
       Inferno.render(
         <MultipleViewersComponent
-          viewers={{ huey: viewer1V, dewey: viewer2V, louie: viewer3V }}
+          viewers={{ huey: viewer1B, dewey: viewer2B, louie: viewer3B }}
+          transforms={{ dewey: deweyTransform }}
           name={"test-component"}
         />,
         root

--- a/test/dom/iml/as-viewer/as-viewer-test.js
+++ b/test/dom/iml/as-viewer/as-viewer-test.js
@@ -203,8 +203,18 @@ describe("as viewers", () => {
       jest.spyOn(viewer3V, "destroy");
 
       MultipleViewersComponent = asViewers(
-        ["viewer1", "viewer2", "viewer3"],
-        ({ viewer1: { key1 }, viewer2: { key2 }, viewer3: { key3 }, name }) => {
+        ({
+          huey: {
+            viewer1: { key1 }
+          },
+          dewey: {
+            viewer2: { key2 }
+          },
+          louie: {
+            viewer3: { key3 }
+          },
+          name
+        }) => {
           return (
             <div id="multiple-viewers-component">
               <h1 id="name">{name}</h1>
@@ -218,7 +228,10 @@ describe("as viewers", () => {
 
       root = document.createElement("div");
       Inferno.render(
-        <MultipleViewersComponent viewers={[viewer1V, viewer2V, viewer3V]} name={"test-component"} />,
+        <MultipleViewersComponent
+          viewers={{ huey: viewer1V, dewey: viewer2V, louie: viewer3V }}
+          name={"test-component"}
+        />,
         root
       );
     });
@@ -243,19 +256,6 @@ describe("as viewers", () => {
       it("should end the broadcast for viewer3", () => {
         expect(viewer3V.destroy).toHaveBeenCalledTimes(1);
       });
-    });
-  });
-
-  describe("with duplicate keys", () => {
-    beforeEach(() => {});
-
-    it("should throw an exception", () => {
-      expect(
-        () =>
-          (MultipleViewersComponent = asViewers(["viewer1", "viewer2", "viewer3", "viewer3"], () => {
-            return <div id="multiple-viewers-component" />;
-          }))
-      ).toThrow(new Error("asViewers keys must be unique."));
     });
   });
 });


### PR DESCRIPTION
An inferno component may use multiple viewers. We should use asViewers
to extract the data from each of the viewers into the component being
passed in.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>