### PR TITLE
Integrate Immer.js and update reducers to use it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1764,7 +1764,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -1817,7 +1817,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -3679,7 +3679,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
@@ -5003,7 +5003,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -5582,6 +5582,12 @@
       "dev": true,
       "optional": true
     },
+    "immer": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-1.7.2.tgz",
+      "integrity": "sha512-4Urocwu9+XLDJw4Tc6ZCg7APVjjLInCFvO4TwGsAYV5zT6YYSor14dsZR0+0tHlDIN92cFUOq+i7fC00G5vTxA==",
+      "dev": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -5698,7 +5704,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5730,7 +5736,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -10256,7 +10262,7 @@
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
@@ -10644,7 +10650,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "highland": "3.0.0-beta.5",
     "html-loader": "^0.5.0",
     "html-webpack-plugin": "^2.30.1",
+    "immer": "^1.7.2",
     "inferno": "^3.7.1",
     "inferno-component": "^3.7.1",
     "jest": "^20.0.4",

--- a/source/iml/agent-vs-copytool/agent-vs-copytool-chart-reducer.js
+++ b/source/iml/agent-vs-copytool/agent-vs-copytool-chart-reducer.js
@@ -9,6 +9,7 @@ export const UPDATE_AGENT_VS_COPYTOOL_CHART_ITEMS = "UPDATE_AGENT_VS_COPYTOOL_CH
 export const DEFAULT_AGENT_VS_COPYTOOL_CHART_ITEMS = "DEFAULT_AGENT_VS_COPYTOOL_CHART_ITEMS";
 
 import produce from "immer";
+import { smartSpread } from "../immutability-utils";
 
 import type { durationPayloadHashT } from "../duration-picker/duration-picker-module.js";
 import type { addAgentVsCopytoolActionT } from "./agent-vs-copytool-module.js";
@@ -20,9 +21,7 @@ export default (state: durationPayloadHashT = {}, { type, payload }: addAgentVsC
         if (!draft[payload.page]) draft[payload.page] = payload;
         break;
       case UPDATE_AGENT_VS_COPYTOOL_CHART_ITEMS:
-        Object.entries(payload).forEach(([key, val]) => {
-          draft[payload.page][key] = val;
-        });
+        draft[payload.page] = smartSpread(draft[payload.page], payload);
         break;
     }
   });

--- a/source/iml/agent-vs-copytool/agent-vs-copytool-chart-reducer.js
+++ b/source/iml/agent-vs-copytool/agent-vs-copytool-chart-reducer.js
@@ -18,7 +18,7 @@ export default (state: durationPayloadHashT = {}, { type, payload }: addAgentVsC
   produce(state, (draft: durationPayloadHashT) => {
     switch (type) {
       case DEFAULT_AGENT_VS_COPYTOOL_CHART_ITEMS:
-        if (!draft[payload.page]) draft[payload.page] = payload;
+        if (!draft[payload.page]) draft[payload.page] = smartSpread(payload);
         break;
       case UPDATE_AGENT_VS_COPYTOOL_CHART_ITEMS:
         draft[payload.page] = smartSpread(draft[payload.page], payload);

--- a/source/iml/agent-vs-copytool/agent-vs-copytool-chart-reducer.js
+++ b/source/iml/agent-vs-copytool/agent-vs-copytool-chart-reducer.js
@@ -8,29 +8,19 @@
 export const UPDATE_AGENT_VS_COPYTOOL_CHART_ITEMS = "UPDATE_AGENT_VS_COPYTOOL_CHART_ITEMS";
 export const DEFAULT_AGENT_VS_COPYTOOL_CHART_ITEMS = "DEFAULT_AGENT_VS_COPYTOOL_CHART_ITEMS";
 
-import type { durationPayloadHashT, durationPayloadT } from "../duration-picker/duration-picker-module.js";
+import produce from "immer";
 
+import type { durationPayloadHashT } from "../duration-picker/duration-picker-module.js";
 import type { addAgentVsCopytoolActionT } from "./agent-vs-copytool-module.js";
 
-function mergeState(state: durationPayloadHashT, payload: durationPayloadT) {
-  return Object.assign({}, state, {
-    [payload.page]: { ...state[payload.page], ...payload }
-  });
-}
-
-export default function(
-  state: durationPayloadHashT = {},
-  { type, payload }: addAgentVsCopytoolActionT
-): durationPayloadHashT {
-  switch (type) {
-    case DEFAULT_AGENT_VS_COPYTOOL_CHART_ITEMS:
-      if (!state[payload.page]) state = mergeState(state, payload);
-
-      return state;
-    case UPDATE_AGENT_VS_COPYTOOL_CHART_ITEMS:
-      return mergeState(state, payload);
-
-    default:
-      return state;
-  }
-}
+export default (state: durationPayloadHashT = {}, { type, payload }: addAgentVsCopytoolActionT): durationPayloadHashT =>
+  produce(state, draft => {
+    switch (type) {
+      case DEFAULT_AGENT_VS_COPYTOOL_CHART_ITEMS:
+        if (!draft[payload.page]) draft[payload.page] = payload;
+        break;
+      case UPDATE_AGENT_VS_COPYTOOL_CHART_ITEMS:
+        draft[payload.page] = { ...state[payload.page], ...payload };
+        break;
+    }
+  }) || {};

--- a/source/iml/agent-vs-copytool/agent-vs-copytool-chart-reducer.js
+++ b/source/iml/agent-vs-copytool/agent-vs-copytool-chart-reducer.js
@@ -14,7 +14,7 @@ import type { durationPayloadHashT } from "../duration-picker/duration-picker-mo
 import type { addAgentVsCopytoolActionT } from "./agent-vs-copytool-module.js";
 
 export default (state: durationPayloadHashT = {}, { type, payload }: addAgentVsCopytoolActionT): durationPayloadHashT =>
-  produce(state, draft => {
+  produce(state, (draft: durationPayloadHashT) => {
     switch (type) {
       case DEFAULT_AGENT_VS_COPYTOOL_CHART_ITEMS:
         if (!draft[payload.page]) draft[payload.page] = payload;
@@ -25,4 +25,4 @@ export default (state: durationPayloadHashT = {}, { type, payload }: addAgentVsC
         });
         break;
     }
-  }) || {};
+  });

--- a/source/iml/agent-vs-copytool/agent-vs-copytool-chart-reducer.js
+++ b/source/iml/agent-vs-copytool/agent-vs-copytool-chart-reducer.js
@@ -20,7 +20,9 @@ export default (state: durationPayloadHashT = {}, { type, payload }: addAgentVsC
         if (!draft[payload.page]) draft[payload.page] = payload;
         break;
       case UPDATE_AGENT_VS_COPYTOOL_CHART_ITEMS:
-        draft[payload.page] = { ...state[payload.page], ...payload };
+        Object.entries(payload).forEach(([key, val]) => {
+          draft[payload.page][key] = val;
+        });
         break;
     }
   }) || {};

--- a/source/iml/alert-indicator/alert-indicator-reducer.js
+++ b/source/iml/alert-indicator/alert-indicator-reducer.js
@@ -7,12 +7,14 @@
 
 export const ADD_ALERT_INDICATOR_ITEMS = "ADD_ALERT_INDICATOR_ITEMS";
 
+import { immutableOriginal } from "../immutability-utils.js";
+
 import type { ActionT } from "../store/store-module.js";
 
-export default function(state: Array<Object> = [], { type, payload }: ActionT): Array<Object> {
+export default function(state: Object[] = [], { type, payload }: ActionT): Object[] {
   switch (type) {
     case ADD_ALERT_INDICATOR_ITEMS:
-      return payload;
+      return payload.map(immutableOriginal);
     default:
       return state;
   }

--- a/source/iml/cpu-usage/cpu-usage-chart-reducer.js
+++ b/source/iml/cpu-usage/cpu-usage-chart-reducer.js
@@ -8,26 +8,22 @@
 export const UPDATE_CPU_USAGE_CHART_ITEMS = "UPDATE_CPU_USAGE_CHART_ITEMS";
 export const DEFAULT_CPU_USAGE_CHART_ITEMS = "DEFAULT_CPU_USAGE_CHART_ITEMS";
 
-import type { durationPayloadHashT, durationPayloadT } from "../duration-picker/duration-picker-module.js";
+import produce from "immer";
+
+import type { durationPayloadHashT } from "../duration-picker/duration-picker-module.js";
 
 import type { addCpuUsageActionT } from "./cpu-usage-module.js";
 
-function mergeState(state: durationPayloadHashT, payload: durationPayloadT) {
-  return Object.assign({}, state, {
-    [payload.page]: { ...state[payload.page], ...payload }
+export default (state: durationPayloadHashT = {}, { type, payload }: addCpuUsageActionT): durationPayloadHashT =>
+  produce(state, (draft: durationPayloadHashT) => {
+    switch (type) {
+      case DEFAULT_CPU_USAGE_CHART_ITEMS:
+        if (!state[payload.page]) draft[payload.page] = payload;
+        break;
+      case UPDATE_CPU_USAGE_CHART_ITEMS:
+        Object.entries(payload).forEach(([key, val]) => {
+          draft[payload.page][key] = val;
+        });
+        break;
+    }
   });
-}
-
-export default function(state: durationPayloadHashT = {}, { type, payload }: addCpuUsageActionT): durationPayloadHashT {
-  switch (type) {
-    case DEFAULT_CPU_USAGE_CHART_ITEMS:
-      if (!state[payload.page]) state = mergeState(state, payload);
-
-      return state;
-    case UPDATE_CPU_USAGE_CHART_ITEMS:
-      return mergeState(state, payload);
-
-    default:
-      return state;
-  }
-}

--- a/source/iml/cpu-usage/cpu-usage-chart-reducer.js
+++ b/source/iml/cpu-usage/cpu-usage-chart-reducer.js
@@ -9,9 +9,9 @@ export const UPDATE_CPU_USAGE_CHART_ITEMS = "UPDATE_CPU_USAGE_CHART_ITEMS";
 export const DEFAULT_CPU_USAGE_CHART_ITEMS = "DEFAULT_CPU_USAGE_CHART_ITEMS";
 
 import produce from "immer";
+import { smartSpread } from "../immutability-utils";
 
 import type { durationPayloadHashT } from "../duration-picker/duration-picker-module.js";
-
 import type { addCpuUsageActionT } from "./cpu-usage-module.js";
 
 export default (state: durationPayloadHashT = {}, { type, payload }: addCpuUsageActionT): durationPayloadHashT =>
@@ -21,9 +21,7 @@ export default (state: durationPayloadHashT = {}, { type, payload }: addCpuUsage
         if (!state[payload.page]) draft[payload.page] = payload;
         break;
       case UPDATE_CPU_USAGE_CHART_ITEMS:
-        Object.entries(payload).forEach(([key, val]) => {
-          draft[payload.page][key] = val;
-        });
+        draft[payload.page] = smartSpread(draft[payload.page], payload);
         break;
     }
   });

--- a/source/iml/cpu-usage/cpu-usage-chart-reducer.js
+++ b/source/iml/cpu-usage/cpu-usage-chart-reducer.js
@@ -18,7 +18,7 @@ export default (state: durationPayloadHashT = {}, { type, payload }: addCpuUsage
   produce(state, (draft: durationPayloadHashT) => {
     switch (type) {
       case DEFAULT_CPU_USAGE_CHART_ITEMS:
-        if (!state[payload.page]) draft[payload.page] = payload;
+        if (!state[payload.page]) draft[payload.page] = smartSpread(payload);
         break;
       case UPDATE_CPU_USAGE_CHART_ITEMS:
         draft[payload.page] = smartSpread(draft[payload.page], payload);

--- a/source/iml/file-system/file-system-reducer.js
+++ b/source/iml/file-system/file-system-reducer.js
@@ -7,12 +7,14 @@
 
 export const ADD_FS_ITEMS = "ADD_FS_ITEMS";
 
+import { immutableOriginal } from "../immutability-utils.js";
+
 import type { ActionT } from "../store/store-module.js";
 
 export default function(state: Array<Object> = [], { type, payload }: ActionT): Array<Object> {
   switch (type) {
     case ADD_FS_ITEMS:
-      return payload;
+      return payload.map(immutableOriginal);
     default:
       return state;
   }

--- a/source/iml/file-usage/file-usage-chart-reducer.js
+++ b/source/iml/file-usage/file-usage-chart-reducer.js
@@ -8,29 +8,20 @@
 export const UPDATE_FILE_USAGE_CHART_ITEMS = "UPDATE_FILE_USAGE_CHART_ITEMS";
 export const DEFAULT_FILE_USAGE_CHART_ITEMS = "DEFAULT_FILE_USAGE_CHART_ITEMS";
 
-import type { durationPayloadHashT, durationPayloadT } from "../duration-picker/duration-picker-module.js";
+import produce from "immer";
+import { smartSpread } from "../immutability-utils";
 
+import type { durationPayloadHashT } from "../duration-picker/duration-picker-module.js";
 import type { addFileUsageActionT } from "./file-usage-module.js";
 
-function mergeState(state: durationPayloadHashT, payload: durationPayloadT) {
-  return Object.assign({}, state, {
-    [payload.page]: { ...state[payload.page], ...payload }
+export default (state: durationPayloadHashT = {}, { type, payload }: addFileUsageActionT): durationPayloadHashT =>
+  produce(state, (draft: durationPayloadHashT) => {
+    switch (type) {
+      case DEFAULT_FILE_USAGE_CHART_ITEMS:
+        if (!state[payload.page]) draft[payload.page] = smartSpread(payload);
+        break;
+      case UPDATE_FILE_USAGE_CHART_ITEMS:
+        draft[payload.page] = smartSpread(draft[payload.page], payload);
+        break;
+    }
   });
-}
-
-export default function(
-  state: durationPayloadHashT = {},
-  { type, payload }: addFileUsageActionT
-): durationPayloadHashT {
-  switch (type) {
-    case DEFAULT_FILE_USAGE_CHART_ITEMS:
-      if (!state[payload.page]) state = mergeState(state, payload);
-
-      return state;
-    case UPDATE_FILE_USAGE_CHART_ITEMS:
-      return mergeState(state, payload);
-
-    default:
-      return state;
-  }
-}

--- a/source/iml/host-cpu-ram-chart/host-cpu-ram-chart-reducer.js
+++ b/source/iml/host-cpu-ram-chart/host-cpu-ram-chart-reducer.js
@@ -8,29 +8,20 @@
 export const UPDATE_HOST_CPU_RAM_CHART_ITEMS = "UPDATE_HOST_CPU_RAM_CHART_ITEMS";
 export const DEFAULT_HOST_CPU_RAM_CHART_ITEMS = "DEFAULT_HOST_CPU_RAM_CHART_ITEMS";
 
+import produce from "immer";
+import { smartSpread } from "../immutability-utils";
+
 import type { addHostCpuRamActionT } from "./host-cpu-ram-chart-module.js";
+import type { durationPayloadHashT } from "../duration-picker/duration-picker-module.js";
 
-import type { durationPayloadHashT, durationPayloadT } from "../duration-picker/duration-picker-module.js";
-
-function mergeState(state: durationPayloadHashT, payload: durationPayloadT) {
-  return Object.assign({}, state, {
-    [payload.page]: { ...state[payload.page], ...payload }
+export default (state: durationPayloadHashT = {}, { type, payload }: addHostCpuRamActionT): durationPayloadHashT =>
+  produce(state, (draft: durationPayloadHashT) => {
+    switch (type) {
+      case DEFAULT_HOST_CPU_RAM_CHART_ITEMS:
+        if (!state[payload.page]) draft[payload.page] = smartSpread(payload);
+        break;
+      case UPDATE_HOST_CPU_RAM_CHART_ITEMS:
+        draft[payload.page] = smartSpread(draft[payload.page], payload);
+        break;
+    }
   });
-}
-
-export default function(
-  state: durationPayloadHashT = {},
-  { type, payload }: addHostCpuRamActionT
-): durationPayloadHashT {
-  switch (type) {
-    case DEFAULT_HOST_CPU_RAM_CHART_ITEMS:
-      if (!state[payload.page]) state = mergeState(state, payload);
-
-      return state;
-    case UPDATE_HOST_CPU_RAM_CHART_ITEMS:
-      return mergeState(state, payload);
-
-    default:
-      return state;
-  }
-}

--- a/source/iml/iml-module.js
+++ b/source/iml/iml-module.js
@@ -5,6 +5,12 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+declare var process: {
+  env: {
+    NODE_ENV: string
+  }
+};
+
 import "font-awesome-webpack";
 import "../styles/imports.less";
 import "../favicon.ico";
@@ -110,6 +116,9 @@ import help from "./help.js";
 import windowUnload from "./window-unload.js";
 import disconnectModal from "./disconnect-modal/disconnect-modal.js";
 import disconnectListener from "./disconnect-modal/disconnect-listener.js";
+import { setAutoFreeze } from "immer";
+
+setAutoFreeze(process.env.NODE_ENV !== "production");
 
 const imlModule = angular
   .module("iml", [

--- a/source/iml/immutability-utils.js
+++ b/source/iml/immutability-utils.js
@@ -1,0 +1,14 @@
+// @flow
+
+//
+// Copyright (c) 2018 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import produce from "immer";
+
+type TToT = <T>(T: T) => T | void;
+const draftToOriginal: TToT = () => undefined;
+
+export const immutableOriginal = produce((draftToOriginal: TToT));
+export const smartSpread = ((produce((Object.assign: any)): any): (...args: Object[]) => Object);

--- a/source/iml/job-indicator/job-indicator-reducer.js
+++ b/source/iml/job-indicator/job-indicator-reducer.js
@@ -7,12 +7,14 @@
 
 import { ADD_JOB_INDICATOR_ITEMS } from "./job-indicator.js";
 
+import { immutableOriginal } from "../immutability-utils.js";
+
 import type { ActionT } from "../store/store-module.js";
 
 export default function(state: Array<Object> = [], { type, payload }: ActionT): Array<Object> {
   switch (type) {
     case ADD_JOB_INDICATOR_ITEMS:
-      return payload;
+      return payload.map(immutableOriginal);
     default:
       return state;
   }

--- a/source/iml/job-stats/job-stats-reducer.js
+++ b/source/iml/job-stats/job-stats-reducer.js
@@ -8,6 +8,8 @@
 export const SET_DURATION = "SET_DURATION";
 export const SET_SORT = "SET_SORT";
 
+import { smartSpread } from "../immutability-utils";
+
 import type { ActionT } from "../store/store-module.js";
 
 const startingState = {
@@ -19,15 +21,8 @@ const startingState = {
 export default function(state: Object = startingState, { type, payload }: ActionT): Object {
   switch (type) {
     case SET_DURATION:
-      return {
-        ...state,
-        ...payload
-      };
     case SET_SORT:
-      return {
-        ...state,
-        ...payload
-      };
+      return smartSpread(state, payload);
     default:
       return state;
   }

--- a/source/iml/lnet/lnet-configuration-reducer.js
+++ b/source/iml/lnet/lnet-configuration-reducer.js
@@ -7,12 +7,14 @@
 
 import type { ActionT } from "../store/store-module.js";
 
+import { immutableOriginal } from "../immutability-utils.js";
+
 export const ADD_LNET_CONFIGURATION_ITEMS = "ADD_LNET_CONFIGURATION_ITEMS";
 
 export default function(state: Array<Object> = [], { type, payload }: ActionT): Array<Object> {
   switch (type) {
     case ADD_LNET_CONFIGURATION_ITEMS:
-      return payload;
+      return payload.map(immutableOriginal);
     default:
       return state;
   }

--- a/source/iml/login/login-form-reducer.js
+++ b/source/iml/login/login-form-reducer.js
@@ -5,6 +5,8 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+import { smartSpread } from "../immutability-utils";
+
 import type { Exact } from "../../flow-workarounds.js";
 
 export const ADD_ERRORS = "ADD_ERRORS";
@@ -41,9 +43,7 @@ export type loginFormT = Exact<{
 export default (state: loginFormT = { inProgress: false }, actions: loginFormActionsT): loginFormT => {
   switch (actions.type) {
     case ADD_ERRORS:
-      return {
-        ...actions.payload
-      };
+      return smartSpread(actions.payload);
     case ADD_IN_PROGRESS:
       return {
         inProgress: actions.payload.inProgress

--- a/source/iml/mdo/mdo-chart-reducer.js
+++ b/source/iml/mdo/mdo-chart-reducer.js
@@ -8,26 +8,21 @@
 export const UPDATE_MDO_CHART_ITEMS = "UPDATE_MDO_CHART_ITEMS";
 export const DEFAULT_MDO_CHART_ITEMS = "DEFAULT_MDO_CHART_ITEMS";
 
-import type { durationPayloadHashT, durationPayloadT } from "../duration-picker/duration-picker-module.js";
+import produce from "immer";
+import { smartSpread } from "../immutability-utils";
+
+import type { durationPayloadHashT } from "../duration-picker/duration-picker-module.js";
 
 import type { addMdoActionT } from "./mdo-module.js";
 
-function mergeState(state: durationPayloadHashT, payload: durationPayloadT) {
-  return Object.assign({}, state, {
-    [payload.page]: { ...state[payload.page], ...payload }
+export default (state: durationPayloadHashT = {}, { type, payload }: addMdoActionT): durationPayloadHashT =>
+  produce(state, (draft: durationPayloadHashT) => {
+    switch (type) {
+      case DEFAULT_MDO_CHART_ITEMS:
+        if (!state[payload.page]) draft[payload.page] = smartSpread(payload);
+        break;
+      case UPDATE_MDO_CHART_ITEMS:
+        draft[payload.page] = smartSpread(draft[payload.page], payload);
+        break;
+    }
   });
-}
-
-export default function(state: durationPayloadHashT = {}, { type, payload }: addMdoActionT): durationPayloadHashT {
-  switch (type) {
-    case DEFAULT_MDO_CHART_ITEMS:
-      if (!state[payload.page]) state = mergeState(state, payload);
-
-      return state;
-    case UPDATE_MDO_CHART_ITEMS:
-      return mergeState(state, payload);
-
-    default:
-      return state;
-  }
-}

--- a/source/iml/memory-usage/memory-usage-chart-reducer.js
+++ b/source/iml/memory-usage/memory-usage-chart-reducer.js
@@ -8,29 +8,20 @@
 export const UPDATE_MEMORY_USAGE_CHART_ITEMS = "UPDATE_MEMORY_USAGE_CHART_ITEMS";
 export const DEFAULT_MEMORY_USAGE_CHART_ITEMS = "DEFAULT_MEMORY_USAGE_CHART_ITEMS";
 
-import type { durationPayloadHashT, durationPayloadT } from "../duration-picker/duration-picker-module.js";
+import produce from "immer";
+import { smartSpread } from "../immutability-utils";
 
+import type { durationPayloadHashT } from "../duration-picker/duration-picker-module.js";
 import type { addMemoryUsageActionT } from "./memory-usage-module.js";
 
-function mergeState(state: durationPayloadHashT, payload: durationPayloadT) {
-  return Object.assign({}, state, {
-    [payload.page]: { ...state[payload.page], ...payload }
+export default (state: durationPayloadHashT = {}, { type, payload }: addMemoryUsageActionT): durationPayloadHashT =>
+  produce(state, (draft: durationPayloadHashT) => {
+    switch (type) {
+      case DEFAULT_MEMORY_USAGE_CHART_ITEMS:
+        if (!state[payload.page]) draft[payload.page] = smartSpread(payload);
+        break;
+      case UPDATE_MEMORY_USAGE_CHART_ITEMS:
+        draft[payload.page] = smartSpread(draft[payload.page], payload);
+        break;
+    }
   });
-}
-
-export default function(
-  state: durationPayloadHashT = {},
-  { type, payload }: addMemoryUsageActionT
-): durationPayloadHashT {
-  switch (type) {
-    case DEFAULT_MEMORY_USAGE_CHART_ITEMS:
-      if (!state[payload.page]) state = mergeState(state, payload);
-
-      return state;
-    case UPDATE_MEMORY_USAGE_CHART_ITEMS:
-      return mergeState(state, payload);
-
-    default:
-      return state;
-  }
-}

--- a/source/iml/ost-balance/ost-balance-chart-reducer.js
+++ b/source/iml/ost-balance/ost-balance-chart-reducer.js
@@ -8,27 +8,19 @@
 export const UPDATE_OST_BALANCE_CHART_ITEMS = "UPDATE_OST_BALANCE_CHART_ITEMS";
 export const DEFAULT_OST_BALANCE_CHART_ITEMS = "DEFAULT_OST_BALANCE_CHART_ITEMS";
 
-import type { ostBalancePayloadT, ostBalancePayloadHashT, addOstBalanceActionT } from "./ost-balance-module.js";
+import produce from "immer";
+import { smartSpread } from "../immutability-utils";
 
-function mergeState(state: ostBalancePayloadHashT, payload: ostBalancePayloadT) {
-  return Object.assign({}, state, {
-    [payload.page]: { ...state[payload.page], ...payload }
+import type { ostBalancePayloadHashT, addOstBalanceActionT } from "./ost-balance-module.js";
+
+export default (state: ostBalancePayloadHashT = {}, { type, payload }: addOstBalanceActionT): ostBalancePayloadHashT =>
+  produce(state, (draft: ostBalancePayloadHashT) => {
+    switch (type) {
+      case DEFAULT_OST_BALANCE_CHART_ITEMS:
+        if (!state[payload.page]) draft[payload.page] = smartSpread(payload);
+        break;
+      case UPDATE_OST_BALANCE_CHART_ITEMS:
+        draft[payload.page] = smartSpread(draft[payload.page], payload);
+        break;
+    }
   });
-}
-
-export default function(
-  state: ostBalancePayloadHashT = {},
-  { type, payload }: addOstBalanceActionT
-): ostBalancePayloadHashT {
-  switch (type) {
-    case DEFAULT_OST_BALANCE_CHART_ITEMS:
-      if (!state[payload.page]) state = mergeState(state, payload);
-
-      return state;
-    case UPDATE_OST_BALANCE_CHART_ITEMS:
-      return mergeState(state, payload);
-
-    default:
-      return state;
-  }
-}

--- a/source/iml/read-write-bandwidth/read-write-bandwidth-chart-reducer.js
+++ b/source/iml/read-write-bandwidth/read-write-bandwidth-chart-reducer.js
@@ -8,29 +8,20 @@
 export const UPDATE_READ_WRITE_BANDWIDTH_CHART_ITEMS = "UPDATE_READ_WRITE_BANDWIDTH_CHART_ITEMS";
 export const DEFAULT_READ_WRITE_BANDWIDTH_CHART_ITEMS = "DEFAULT_READ_WRITE_BANDWIDTH_CHART_ITEMS";
 
+import produce from "immer";
+import { smartSpread } from "../immutability-utils";
+
 import type { readWriteBandwidthActionT } from "./read-write-bandwidth-module.js";
+import type { durationPayloadHashT } from "../duration-picker/duration-picker-module.js";
 
-import type { durationPayloadHashT, durationPayloadT } from "../duration-picker/duration-picker-module.js";
-
-function mergeState(state: durationPayloadHashT, payload: durationPayloadT) {
-  return Object.assign({}, state, {
-    [payload.page]: { ...state[payload.page], ...payload }
+export default (state: durationPayloadHashT = {}, { type, payload }: readWriteBandwidthActionT): durationPayloadHashT =>
+  produce(state, (draft: durationPayloadHashT) => {
+    switch (type) {
+      case DEFAULT_READ_WRITE_BANDWIDTH_CHART_ITEMS:
+        if (!state[payload.page]) draft[payload.page] = smartSpread(payload);
+        break;
+      case UPDATE_READ_WRITE_BANDWIDTH_CHART_ITEMS:
+        draft[payload.page] = smartSpread(draft[payload.page], payload);
+        break;
+    }
   });
-}
-
-export default function(
-  state: durationPayloadHashT = {},
-  { type, payload }: readWriteBandwidthActionT
-): durationPayloadHashT {
-  switch (type) {
-    case DEFAULT_READ_WRITE_BANDWIDTH_CHART_ITEMS:
-      if (!state[payload.page]) state = mergeState(state, payload);
-
-      return state;
-    case UPDATE_READ_WRITE_BANDWIDTH_CHART_ITEMS:
-      return mergeState(state, payload);
-
-    default:
-      return state;
-  }
-}

--- a/source/iml/read-write-heat-map/read-write-heat-map-chart-reducer.js
+++ b/source/iml/read-write-heat-map/read-write-heat-map-chart-reducer.js
@@ -8,31 +8,19 @@
 export const UPDATE_READ_WRITE_HEAT_MAP_CHART_ITEMS = "UPDATE_READ_WRITE_HEAT_MAP_CHART_ITEMS";
 export const DEFAULT_READ_WRITE_HEAT_MAP_CHART_ITEMS = "DEFAULT_READ_WRITE_HEAT_MAP_CHART_ITEMS";
 
-import type {
-  heatMapPayloadHashT,
-  addReadWriteHeatMapActionT,
-  heatMapDurationPayloadT
-} from "./read-write-heat-map-module.js";
+import produce from "immer";
+import { smartSpread } from "../immutability-utils";
 
-function mergeState(state: heatMapPayloadHashT, payload: heatMapDurationPayloadT) {
-  return Object.assign({}, state, {
-    [payload.page]: { ...state[payload.page], ...payload }
+import type { heatMapPayloadHashT, addReadWriteHeatMapActionT } from "./read-write-heat-map-module.js";
+
+export default (state: heatMapPayloadHashT = {}, { type, payload }: addReadWriteHeatMapActionT): heatMapPayloadHashT =>
+  produce(state, (draft: heatMapPayloadHashT) => {
+    switch (type) {
+      case DEFAULT_READ_WRITE_HEAT_MAP_CHART_ITEMS:
+        if (!state[payload.page]) draft[payload.page] = smartSpread(payload);
+        break;
+      case UPDATE_READ_WRITE_HEAT_MAP_CHART_ITEMS:
+        draft[payload.page] = smartSpread(draft[payload.page], payload);
+        break;
+    }
   });
-}
-
-export default function(
-  state: heatMapPayloadHashT = {},
-  { type, payload }: addReadWriteHeatMapActionT
-): heatMapPayloadHashT {
-  switch (type) {
-    case DEFAULT_READ_WRITE_HEAT_MAP_CHART_ITEMS:
-      if (!state[payload.page]) state = mergeState(state, payload);
-
-      return state;
-    case UPDATE_READ_WRITE_HEAT_MAP_CHART_ITEMS:
-      return mergeState(state, payload);
-
-    default:
-      return state;
-  }
-}

--- a/source/iml/server/server-reducer.js
+++ b/source/iml/server/server-reducer.js
@@ -7,12 +7,14 @@
 
 export const ADD_SERVER_ITEMS = "ADD_SERVER_ITEMS";
 
+import { immutableOriginal } from "../immutability-utils.js";
+
 import type { ActionT } from "../store/store-module.js";
 
 export default function(state: Array<Object> = [], { type, payload }: ActionT): Array<Object> {
   switch (type) {
     case ADD_SERVER_ITEMS:
-      return payload;
+      return payload.map(immutableOriginal);
     default:
       return state;
   }

--- a/source/iml/session/session-reducer.js
+++ b/source/iml/session/session-reducer.js
@@ -29,7 +29,7 @@ type stateT = {
 };
 
 export default (state: stateT = {}, { type, payload }: { type: string, payload: stateT }): stateT =>
-  produce(state, draft => {
+  produce(state, (draft: stateT) => {
     switch (type) {
       case SET_SESSION:
         draft.session = payload.session;
@@ -38,4 +38,4 @@ export default (state: stateT = {}, { type, payload }: { type: string, payload: 
         draft.cookie = payload.cookie;
         break;
     }
-  }) || {};
+  });

--- a/source/iml/session/session-reducer.js
+++ b/source/iml/session/session-reducer.js
@@ -8,6 +8,8 @@
 export const SET_SESSION = "SET_SESSION";
 export const SET_COOKIE = "SET_COOKIE";
 
+import produce from "immer";
+
 import type { sessionT } from "../api-types.js";
 
 import type { Exact } from "../../flow-workarounds.js";
@@ -21,26 +23,19 @@ export type cookieActionT = Exact<{
   payload: { cookie: string }
 }>;
 
-export type sessionActionsT = sessionActionT | cookieActionT | Exact<{ type: string, payload: any }>;
-
 type stateT = {
   session?: sessionT,
   cookie?: string
 };
 
-export default (state: stateT = {}, actions: sessionActionsT): stateT => {
-  switch (actions.type) {
-    case SET_SESSION:
-      return {
-        ...state,
-        ...actions.payload
-      };
-    case SET_COOKIE:
-      return {
-        ...state,
-        ...actions.payload
-      };
-    default:
-      return state;
-  }
-};
+export default (state: stateT = {}, { type, payload }: { type: string, payload: stateT }): stateT =>
+  produce(state, draft => {
+    switch (type) {
+      case SET_SESSION:
+        draft.session = payload.session;
+        break;
+      case SET_COOKIE:
+        draft.cookie = payload.cookie;
+        break;
+    }
+  }) || {};

--- a/source/iml/space-usage/space-usage-chart-reducer.js
+++ b/source/iml/space-usage/space-usage-chart-reducer.js
@@ -8,29 +8,20 @@
 export const UPDATE_SPACE_USAGE_CHART_ITEMS = "UPDATE_SPACE_USAGE_CHART_ITEMS";
 export const DEFAULT_SPACE_USAGE_CHART_ITEMS = "DEFAULT_SPACE_USAGE_CHART_ITEMS";
 
-import type { durationPayloadHashT, durationPayloadT } from "../duration-picker/duration-picker-module.js";
+import produce from "immer";
+import { smartSpread } from "../immutability-utils";
 
+import type { durationPayloadHashT } from "../duration-picker/duration-picker-module.js";
 import type { addSpaceUsageActionT } from "./space-usage-module.js";
 
-function mergeState(state: durationPayloadHashT, payload: durationPayloadT) {
-  return Object.assign({}, state, {
-    [payload.page]: { ...state[payload.page], ...payload }
+export default (state: durationPayloadHashT = {}, { type, payload }: addSpaceUsageActionT): durationPayloadHashT =>
+  produce(state, (draft: durationPayloadHashT) => {
+    switch (type) {
+      case DEFAULT_SPACE_USAGE_CHART_ITEMS:
+        if (!state[payload.page]) draft[payload.page] = smartSpread(payload);
+        break;
+      case UPDATE_SPACE_USAGE_CHART_ITEMS:
+        draft[payload.page] = smartSpread(draft[payload.page], payload);
+        break;
+    }
   });
-}
-
-export default function(
-  state: durationPayloadHashT = {},
-  { type, payload }: addSpaceUsageActionT
-): durationPayloadHashT {
-  switch (type) {
-    case DEFAULT_SPACE_USAGE_CHART_ITEMS:
-      if (!state[payload.page]) state = mergeState(state, payload);
-
-      return state;
-    case UPDATE_SPACE_USAGE_CHART_ITEMS:
-      return mergeState(state, payload);
-
-    default:
-      return state;
-  }
-}

--- a/source/iml/storage/storage-reducer.js
+++ b/source/iml/storage/storage-reducer.js
@@ -5,6 +5,9 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+import produce from "immer";
+import { smartSpread } from "../immutability-utils";
+
 import type { StorageResourceClass, StorageResourceResponse } from "./storage-types.js";
 import type { ActionT } from "../store/store-module.js";
 
@@ -30,7 +33,18 @@ export const SET_STORAGE_SORTING = "SET_STORAGE_SORTING";
 export const SET_STORAGE_TABLE_LOADING = "SET_STORAGE_TABLE_LOADING";
 export const SET_STORAGE_CONFIG = "SET_STORAGE_CONFIG";
 
-export default function(
+const handleSorting = (lastState: State, sortKey: string) => {
+  let sortDesc = false;
+
+  if (lastState.config.sortKey === sortKey) sortDesc = true;
+
+  return {
+    sortKey,
+    sortDesc
+  };
+};
+
+export default (
   state: State = {
     resourceClasses: null,
     resources: null,
@@ -44,69 +58,33 @@ export default function(
     }
   },
   { type, payload }: ActionT
-): State {
-  switch (type) {
-    case ADD_STORAGE_RESOURCE_CLASSES:
-      return {
-        ...state,
-        resourceClasses: payload
-      };
-    case ADD_STORAGE_RESOURCES:
-      return {
-        ...state,
-        resources: payload
-      };
-    case SET_STORAGE_SELECT_INDEX:
-      return {
-        ...state,
-        config: {
-          ...state.config,
+): State =>
+  produce(state, (draft: State) => {
+    switch (type) {
+      case ADD_STORAGE_RESOURCE_CLASSES:
+        draft["resourceClasses"] = payload;
+        break;
+      case ADD_STORAGE_RESOURCES:
+        draft["resources"] = payload;
+        break;
+      case SET_STORAGE_SELECT_INDEX:
+        draft["config"] = smartSpread(state.config, {
           selectIndex: payload,
           sortKey: "",
           sortDesc: false,
           loading: false,
           entries: 10,
           offset: 0
-        }
-      };
-    case SET_STORAGE_SORTING:
-      return {
-        ...state,
-        config: {
-          ...state.config,
-          ...handleSorting(state, payload)
-        }
-      };
-    case SET_STORAGE_TABLE_LOADING:
-      if (payload === state.config.loading) return state;
-
-      return {
-        ...state,
-        config: {
-          ...state.config,
-          loading: payload
-        }
-      };
-    case SET_STORAGE_CONFIG:
-      return {
-        ...state,
-        config: {
-          ...state.config,
-          ...payload
-        }
-      };
-    default:
-      return state;
-  }
-}
-
-function handleSorting(lastState: State, sortKey: string) {
-  let sortDesc = false;
-
-  if (lastState.config.sortKey === sortKey) sortDesc = true;
-
-  return {
-    sortKey,
-    sortDesc
-  };
-}
+        });
+        break;
+      case SET_STORAGE_SORTING:
+        draft["config"] = smartSpread(state.config, handleSorting(state, payload));
+        break;
+      case SET_STORAGE_TABLE_LOADING:
+        if (payload !== state.config.loading) draft["config"] = smartSpread(state.config, { loading: payload });
+        break;
+      case SET_STORAGE_CONFIG:
+        draft["config"] = smartSpread(state.config, payload);
+        break;
+    }
+  });

--- a/source/iml/target/target-reducer.js
+++ b/source/iml/target/target-reducer.js
@@ -7,12 +7,14 @@
 
 export const ADD_TARGET_ITEMS = "ADD_TARGET_ITEMS";
 
+import { immutableOriginal } from "../immutability-utils.js";
+
 import type { ActionT } from "../store/store-module.js";
 
 export default function targetReducer(state: Array<Object> = [], { type, payload }: ActionT): Array<Object> {
   switch (type) {
     case ADD_TARGET_ITEMS:
-      return payload;
+      return payload.map(immutableOriginal);
     default:
       return state;
   }

--- a/source/iml/tree/tree-transforms.js
+++ b/source/iml/tree/tree-transforms.js
@@ -15,6 +15,8 @@ import { addCurrentPage } from "../api-transforms.js";
 
 import { addTreeItems, createItem } from "../tree/tree-actions.js";
 
+import { smartSpread } from "../immutability-utils";
+
 import type { Maybe } from "@iml/maybe";
 
 import type { treeItemT, treeHashT } from "./tree-types.js";
@@ -71,7 +73,7 @@ export const transformItems = (
     highland.filter(hasChanges(x => x.meta.offset)),
     flatMapChanges.bind(null, fnTo$),
     highland.map(addCurrentPage),
-    highland.map(x => Object.assign(latest, x)),
+    highland.map(x => smartSpread(latest, x)),
     highland.map(x => addTreeItems([x]))
   );
 };

--- a/source/iml/user/user-reducer.js
+++ b/source/iml/user/user-reducer.js
@@ -7,13 +7,15 @@
 
 export const ADD_USER_ITEMS = "ADD_USER_ITEMS";
 
+import { immutableOriginal } from "../immutability-utils.js";
+
 import type { ActionT } from "../store/store-module.js";
 
-export default function(state: Array<Object> = [], { type, payload }: ActionT): Array<Object> {
+export default (state: Array<Object> = [], { type, payload }: ActionT): Array<Object> => {
   switch (type) {
     case ADD_USER_ITEMS:
-      return payload;
+      return payload.map(immutableOriginal);
     default:
       return state;
   }
-}
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,6 +83,7 @@ const config = {
     ]
   },
   plugins: [
+    new webpack.EnvironmentPlugin(["NODE_ENV"]),
     new webpack.optimize.ModuleConcatenationPlugin(),
     new HtmlWebpackPlugin({
       template: "index.ejs"


### PR DESCRIPTION
Fixes #146.

Description:
Integreating immer will guarantee immutability within the store. This is
crucial for the integration of new items into the store as we need to be
sure that their data is not modified outside their scope.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>