### PR TITLE
Create reducer for locks

### DIFF
--- a/flow-typed/sse.js
+++ b/flow-typed/sse.js
@@ -1,0 +1,31 @@
+// @flow
+
+//
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+declare class SSEEvent extends Event {
+  data: string;
+}
+declare type SSEEventT = SSEEvent;
+
+type CONNECTING = 0;
+type OPEN = 1;
+type CLOSED = 2;
+
+type EventSourceConfigurationT = {|
+  withCredentials: boolean
+|};
+
+declare class EventSource {
+  constructor(url: string, configuration?: EventSourceConfigurationT): EventSource;
+  readyState: CONNECTING | OPEN | CLOSED;
+  url: string;
+  withCredentials: boolean;
+  onerror: (e: Error) => void;
+  onmessage: SSEEventT => void;
+  onopen: () => void;
+  close: () => void;
+}
+declare type EventSourceT = EventSource;

--- a/flow-typed/window.js
+++ b/flow-typed/window.js
@@ -1,7 +1,7 @@
 // @flow
 
 //
-// Copyright (c) 2018 DDN. All rights reserved.
+// Copyright (c) 2019 DDN. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
@@ -53,7 +53,8 @@ declare var window: {
         minimumSignificantDigits?: number
       }
     ) => Object
-  }
+  },
+  EventSource: typeof EventSource
 };
 
 declare module "../favicon.ico" {

--- a/source/iml/environment.js
+++ b/source/iml/environment.js
@@ -18,4 +18,5 @@ export const VERSION = global.VERSION;
 export const BUILD = global.BUILD;
 export const BASE = `${global.location.protocol}//${global.location.hostname}`;
 export const API = `${BASE}:${global.location.port}/api/`;
+export const SSE = `${BASE}:${global.location.port}/messaging`;
 export const RUNTIME_VERSION = IS_RELEASE ? VERSION : `Build ${BUILD}`;

--- a/source/iml/iml-module.js
+++ b/source/iml/iml-module.js
@@ -18,6 +18,7 @@ import "./user/user-dispatch-source.js";
 import "./job-indicator/job-indicator-dispatch-source.js";
 import "./session/session-dispatch-source.js";
 import "./storage/storage-dispatch-source.js";
+import "./sse/sse-handler.js";
 
 import * as ENV from "./environment.js";
 import angular from "angular";

--- a/source/iml/locks/locks-reducer.js
+++ b/source/iml/locks/locks-reducer.js
@@ -1,0 +1,50 @@
+// @flow
+
+//
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import Immutable from "seamless-immutable";
+
+export const UPDATE_LOCKS_ACTION: "UPDATE_LOCKS" = "UPDATE_LOCKS";
+
+export const LOCK_ACTION_ADD: "add" = "add";
+export const LOCK_ACTION_REMOVE: "remove" = "remove";
+
+export const LOCK_TYPE_READ: "read" = "read";
+export const LOCK_TYPE_WRITE: "write" = "write";
+
+type ContentTypeIdT = string;
+type ResourceIdT = string;
+type LockKeyT = ContentTypeIdT | ":" | ResourceIdT;
+
+export type ReadOrWriteT = typeof LOCK_TYPE_READ | typeof LOCK_TYPE_WRITE;
+export type LockToLockEntries = LockT => LockEntryT[];
+
+export type LockEntryT = {|
+  action: typeof LOCK_ACTION_ADD | typeof LOCK_ACTION_REMOVE,
+  content_type_id: number,
+  description: string,
+  item_id: number,
+  job_id: number,
+  lock_type: ReadOrWriteT
+|};
+
+export type LockT = {
+  [key: LockKeyT]: LockEntryT[]
+};
+
+type LockActionT = {|
+  type: typeof UPDATE_LOCKS_ACTION,
+  payload: LockT
+|};
+
+export default function locksReducer(state: LockT = Immutable({}), { type, payload }: LockActionT): LockT {
+  switch (type) {
+    case UPDATE_LOCKS_ACTION:
+      return Immutable(payload);
+    default:
+      return state;
+  }
+}

--- a/source/iml/locks/locks-utils.js
+++ b/source/iml/locks/locks-utils.js
@@ -1,0 +1,18 @@
+// @flow
+
+//
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import { type LockT, type LockEntryT, LOCK_TYPE_READ, LOCK_TYPE_WRITE, type ReadOrWriteT } from "./locks-reducer.js";
+
+const flattenLocks: LockT => LockEntryT[] = (locks: LockT) => ([].concat(...Object.values(locks)): any);
+
+const getLocks = (type: ReadOrWriteT) => (locks: LockT) => {
+  return flattenLocks(locks).filter((x: LockEntryT) => x.lock_type === type);
+};
+
+export const getReadLocks = getLocks(LOCK_TYPE_READ);
+export const getWriteLocks = getLocks(LOCK_TYPE_WRITE);
+export const getAllLocks = flattenLocks;

--- a/source/iml/sse/sse-handler.js
+++ b/source/iml/sse/sse-handler.js
@@ -1,0 +1,18 @@
+// @flow
+
+//
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import getSSEStream from "./sse-stream.js";
+import getStore from "../store/get-store.js";
+
+import { type LockT, UPDATE_LOCKS_ACTION } from "../locks/locks-reducer.js";
+
+getSSEStream().each((data: LockT) => {
+  getStore.dispatch({
+    type: UPDATE_LOCKS_ACTION,
+    payload: data
+  });
+});

--- a/source/iml/sse/sse-stream.js
+++ b/source/iml/sse/sse-stream.js
@@ -1,0 +1,29 @@
+// @flow
+
+//
+// Copyright (c) 2019 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import highland from "highland";
+import global from "../global.js";
+import { SSE } from "../environment.js";
+
+const sse = new global.EventSource(SSE);
+
+export default () =>
+  highland(push => {
+    sse.onerror = (e: Error) => {
+      // pass errors along but don't end the stream
+      push(e);
+    };
+
+    sse.onmessage = (msg: SSEEventT) => {
+      try {
+        const data = JSON.parse(msg.data);
+        push(null, data);
+      } catch (e) {
+        push(e);
+      }
+    };
+  });

--- a/source/iml/store/get-store.js
+++ b/source/iml/store/get-store.js
@@ -30,6 +30,7 @@ import loginFormReducer from "../login/login-form-reducer.js";
 import sessionReducer from "../session/session-reducer.js";
 import storageReducer from "../storage/storage-reducer.js";
 import tzPickerReducer from "../tz-picker/tz-picker-reducer.js";
+import locksReducer from "../locks/locks-reducer.js";
 
 export default createStore({
   agentVsCopytoolCharts: agentVsCopytoolChartReducer,
@@ -54,5 +55,6 @@ export default createStore({
   loginForm: loginFormReducer,
   session: sessionReducer,
   storage: storageReducer,
-  tzPicker: tzPickerReducer
+  tzPicker: tzPickerReducer,
+  locks: locksReducer
 });

--- a/test/spec/iml/locks/locks-reducer-test.js
+++ b/test/spec/iml/locks/locks-reducer-test.js
@@ -1,0 +1,52 @@
+// @flow
+
+import locksReducer, { UPDATE_LOCKS_ACTION, type LockT } from "../../../../source/iml/locks/locks-reducer.js";
+
+describe("locksReducer", () => {
+  let sampleData: LockT;
+
+  beforeEach(() => {
+    sampleData = {
+      "62:1": [
+        {
+          action: "add",
+          content_type_id: 62,
+          description: "Start monitoring LNet on mds1.local",
+          item_id: 1,
+          job_id: 47,
+          lock_type: "read"
+        },
+        {
+          action: "add",
+          content_type_id: 62,
+          description: "Install packages on mds1.local",
+          item_id: 1,
+          job_id: 46,
+          lock_type: "write"
+        }
+      ]
+    };
+  });
+
+  describe("updating locks", () => {
+    describe("from an empty state", () => {
+      it("should return the new state", () => {
+        const result = locksReducer({}, { type: UPDATE_LOCKS_ACTION, payload: sampleData });
+        expect(result).toEqual(sampleData);
+      });
+    });
+
+    describe("from an existing state", () => {
+      it("should return the new state", () => {
+        const existingState = {
+          "62:1": [
+            { ...sampleData["62:1"][0] },
+            { ...sampleData["62:1"][1], description: "Some initial task", job_id: 263 }
+          ]
+        };
+        const result = locksReducer(existingState, { type: UPDATE_LOCKS_ACTION, payload: sampleData });
+        expect(result).toEqual(sampleData);
+      });
+    });
+  });
+});

--- a/test/spec/iml/sse/sse-handler-test.js
+++ b/test/spec/iml/sse/sse-handler-test.js
@@ -1,0 +1,54 @@
+// @flow
+
+import highland from "highland";
+
+import { UPDATE_LOCKS_ACTION } from "../../../../source/iml/locks/locks-reducer.js";
+
+describe("sse handler", () => {
+  let mockGetSSEStream, s$, mockDispatch, samplePayload;
+
+  beforeEach(() => {
+    s$ = highland();
+
+    mockGetSSEStream = jest.fn(() => s$);
+    jest.mock("../../../../source/iml/sse/sse-stream.js", () => mockGetSSEStream);
+
+    mockDispatch = jest.fn();
+    jest.mock("../../../../source/iml/store/get-store.js", () => ({
+      dispatch: mockDispatch
+    }));
+
+    require("../../../../source/iml/sse/sse-handler.js");
+
+    samplePayload = {
+      "62:1": [
+        {
+          action: "add",
+          content_type_id: 62,
+          description: "Start monitoring LNet on mds1.local",
+          item_id: 1,
+          job_id: 47,
+          lock_type: "read"
+        },
+        {
+          action: "add",
+          content_type_id: 62,
+          description: "Install packages on mds1.local",
+          item_id: 1,
+          job_id: 46,
+          lock_type: "write"
+        }
+      ]
+    };
+
+    s$.write(samplePayload);
+  });
+
+  it("should dispatch the data", () => {
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: UPDATE_LOCKS_ACTION,
+      payload: samplePayload
+    });
+  });
+});

--- a/test/spec/iml/sse/sse-stream-test.js
+++ b/test/spec/iml/sse/sse-stream-test.js
@@ -1,0 +1,61 @@
+// @flow
+
+describe("sse stream", () => {
+  let mockSseUrl, mockEventSource, eventSource, getStream, sse$;
+  beforeEach(() => {
+    mockSseUrl = "https://localhost:8443/messaging";
+    jest.mock("../../../../source/iml/environment.js", () => ({
+      SSE: mockSseUrl
+    }));
+
+    eventSource = {};
+    mockEventSource = jest.fn(() => eventSource);
+    jest.mock("../../../../source/iml/global.js", () => ({
+      EventSource: mockEventSource
+    }));
+
+    getStream = require("../../../../source/iml/sse/sse-stream.js").default;
+    sse$ = getStream();
+  });
+
+  it("should push a message down the stream", done => {
+    sse$.each(x => {
+      expect(x).toEqual({
+        key: "val"
+      });
+      done();
+    });
+
+    eventSource.onmessage({
+      data: JSON.stringify({ key: "val" })
+    });
+  });
+
+  it("should push an error if the json can't be parsed", done => {
+    sse$
+      .errors(e => {
+        expect(e).toEqual(new SyntaxError("Unexpected end of JSON input"));
+        done();
+      })
+      .each(() => {
+        done.fail();
+      });
+
+    eventSource.onmessage({
+      data: `{"key": "val}`
+    });
+  });
+
+  it("should handle an error on the event source", done => {
+    sse$
+      .errors(e => {
+        expect(e).toEqual(new Error("oh nooooos"));
+        done();
+      })
+      .each(() => {
+        done.fail();
+      });
+
+    eventSource.onerror(new Error("oh nooooos"));
+  });
+});

--- a/test/spec/iml/store/get-store-test.js
+++ b/test/spec/iml/store/get-store-test.js
@@ -24,7 +24,8 @@ describe("get store", () => {
     mockLoginFormReducer,
     mockSessionReducer,
     mockStorageReducer,
-    mockTzPickerReducer;
+    mockTzPickerReducer,
+    mockLocksReducer;
 
   beforeEach(() => {
     store = { dispatch: jest.fn() };
@@ -52,6 +53,7 @@ describe("get store", () => {
     mockSessionReducer = {};
     mockStorageReducer = {};
     mockTzPickerReducer = {};
+    mockLocksReducer = {};
     jest.mock(
       "../../../../source/iml/read-write-heat-map/read-write-heat-map-chart-reducer.js",
       () => mockReadWriteHeatMapChartReducer
@@ -88,6 +90,7 @@ describe("get store", () => {
     jest.mock("../../../../source/iml/tree/tree-reducer.js", () => mockTreeReducer);
     jest.mock("../../../../source/iml/file-system/file-system-reducer.js", () => mockFileSystemReducer);
     jest.mock("../../../../source/iml/tz-picker/tz-picker-reducer.js", () => mockTzPickerReducer);
+    jest.mock("../../../../source/iml/locks/locks-reducer.js", () => mockLocksReducer);
     const storeModule = require("../../../../source/iml/store/get-store.js");
     storeInstance = storeModule.default;
   });
@@ -119,7 +122,8 @@ describe("get store", () => {
       loginForm: mockLoginFormReducer,
       session: mockSessionReducer,
       storage: mockStorageReducer,
-      tzPicker: mockTzPickerReducer
+      tzPicker: mockTzPickerReducer,
+      locks: mockLocksReducer
     });
   });
 });


### PR DESCRIPTION
Create reducer for locks

Fixes #163.

-  take the output from iml-warp-drive (currently just locks) and place it into a reducer.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>