### PR TITLE
Make items passing through propagateChange mutable

### DIFF
--- a/flow-typed/angular.js
+++ b/flow-typed/angular.js
@@ -82,6 +82,7 @@ declare module angular {
     bootstrap(element: HTMLElement | Document, modules: string[], config: Object): void,
     merge(...rest: Object[]): Object,
     element(el: string | Element): HTMLElement[] & elementExtrasT,
-    injector(): injector
+    injector(): injector,
+    isObject(value: any): boolean
   };
 }

--- a/source/iml/extend-scope-module.js
+++ b/source/iml/extend-scope-module.js
@@ -11,6 +11,8 @@ import type { HighlandStreamT } from "highland";
 
 import type { $scopeT } from "angular";
 
+import Immutable from "seamless-immutable";
+
 export type localApplyT<R> = (scope: $scopeT, fn?: () => R) => ?R;
 
 export type PropagateChange = <T>($scopeT, Object, string, HighlandStreamT<T>) => HighlandStreamT<T>;
@@ -82,6 +84,12 @@ export default angular
     "ngInject";
     return ($scope, obj, prop, s) =>
       s
+        .map(x => {
+          const proceed = Array.isArray(x) || angular.isObject(x);
+
+          if (proceed && Immutable.isImmutable(x)) return Immutable.asMutable(x, { deep: true });
+          else return x;
+        })
         .tap(x => {
           obj[prop] = x;
         })


### PR DESCRIPTION
We are using Seamless Immutable to make sure all data persisted
to the store is immutable, and then removing the immutability before we
cross boundaries where data needs to be mutable, i.e. Inferno or
Angular.

Instead of unwrapping all boundaries manually, we can cover most angular
boundaries by adding a check into `propagateChange` that will ensure
any Seamless Immutable wrapped data that is received becomes mutable
again.

Fixes #176.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>