### PR TITLE
Fix fs-hsm action dropdown

### DIFF
--- a/source/iml/hsm/hsm-fs-controller.js
+++ b/source/iml/hsm/hsm-fs-controller.js
@@ -5,8 +5,6 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-import * as fp from "@iml/fp";
-
 import type { StateServiceT } from "angular-ui-router";
 
 import type { $scopeT } from "angular";
@@ -54,10 +52,10 @@ export default function HsmFsCtrl(
       }
     })
     .each(() => {
-      const fsId = $state.router.globals.params.fsId;
+      const fsId = parseInt($state.router.globals.params.fsId, 10);
 
       if (fsId) {
-        fsStream2 = fsStream().map(fp.find(x => x.id === fsId));
+        fsStream2 = fsStream().map(xs => xs.find(x => x.id === fsId));
         p("fs", fsStream2);
       }
     });

--- a/test/spec/iml/hsm/hsm-fs-controller-test.js
+++ b/test/spec/iml/hsm/hsm-fs-controller-test.js
@@ -2,7 +2,6 @@ import highland from "highland";
 import HsmFsCtrl from "../../../../source/iml/hsm/hsm-fs-controller";
 import broadcaster from "../../../../source/iml/broadcaster.js";
 import angular from "../../../angular-mock-setup.js";
-import * as maybe from "@iml/maybe";
 
 describe("HSM fs controller", () => {
   let ctrl, $scope, $state, $stateParams, fsStream, qsStream, qs$, fsStreamB;
@@ -88,37 +87,35 @@ describe("HSM fs controller", () => {
   });
 
   it("should set fileSystems data", () => {
-    fsStream.write([{ id: "1" }, { id: "2" }]);
+    fsStream.write([{ id: 1 }, { id: 2 }]);
     jest.runAllTimers();
 
-    expect(ctrl.fileSystems).toEqual([{ id: "1" }, { id: "2" }]);
+    expect(ctrl.fileSystems).toEqual([{ id: 1 }, { id: 2 }]);
   });
 
   it("should set fs to the fsId", () => {
     fsStream.write([
       {
-        id: "1",
+        id: 1,
         label: "foo"
       },
       {
-        id: "2",
+        id: 2,
         label: "bar"
       }
     ]);
     jest.runAllTimers();
 
-    expect(ctrl.fs).toEqual(
-      maybe.ofJust({
-        id: "1",
-        label: "foo"
-      })
-    );
+    expect(ctrl.fs).toEqual({
+      id: 1,
+      label: "foo"
+    });
   });
 
   it("should filter out if fsId does not exist", () => {
     $state.router.globals.params.fsId = "";
 
-    fsStream.write([{ id: "1" }]);
+    fsStream.write([{ id: 1 }]);
 
     qs$.write({
       qs: ""
@@ -131,14 +128,14 @@ describe("HSM fs controller", () => {
   it("should alter fs id on change", () => {
     $state.router.globals.params.fsId = "3";
 
-    fsStream.write([{ id: "1" }, { id: "3" }]);
+    fsStream.write([{ id: 1 }, { id: 3 }]);
 
     qs$.write({
       qs: ""
     });
     jest.runAllTimers();
 
-    expect(ctrl.fs).toEqual(maybe.ofJust({ id: "3" }));
+    expect(ctrl.fs).toEqual({ id: 3 });
   });
 
   it("should call qsStream", () => {


### PR DESCRIPTION
- The stream in fs-hsm is comparing a number to a string representation of a number, which will never be equal.
Therefore, the action button will never display. This patch will parse the string into an integer. It also takes out
fp.map as there is no need to use a maybe here.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>