### PR TITLE
Fix Backoff for SSE

### DIFF
--- a/source/iml/sse/sse-stream.js
+++ b/source/iml/sse/sse-stream.js
@@ -12,7 +12,7 @@ import { SSE } from "../environment.js";
 import getStore from "../store/get-store.js";
 import { SET_DISCONNECT_SSE, SET_CONNECT_SSE } from "../disconnect-modal/disconnect-modal-reducer.js";
 
-const backoff = new Backoff({ min: 100, max: 20000 });
+const backoff = new Backoff({ min: 500, max: 20000 });
 
 let token;
 
@@ -37,12 +37,12 @@ export default () =>
           payload: {}
         });
 
-        token = setTimeout(() => {
-          sse.onopen = null;
-          sse.onerror = null;
-          sse.onmessage = null;
-          sse.close();
+        sse.onopen = null;
+        sse.onerror = null;
+        sse.onmessage = null;
+        sse.close();
 
+        token = setTimeout(() => {
           next();
         }, backoff.duration());
       } else {

--- a/test/spec/iml/sse/sse-stream-test.js
+++ b/test/spec/iml/sse/sse-stream-test.js
@@ -43,6 +43,14 @@ describe("sse stream", () => {
     sse$ = getStream();
   });
 
+  it("should initialize Backoff", () => {
+    expect(mockBackoff).toHaveBeenCalledTimes(1);
+    expect(mockBackoff).toHaveBeenCalledWith({
+      min: 500,
+      max: 20000
+    });
+  });
+
   it("should push a message down the stream", done => {
     sse$.each(x => {
       expect(x).toEqual({
@@ -85,61 +93,33 @@ describe("sse stream", () => {
         });
 
         it("should dispatch the disconnect sse modal", () => {
-          sse$
-            .errors(() => {
-              throw new Error("should not have gone in the errors block.");
-            })
-            .each(() => {});
+          sse$.each(() => {});
 
           eventSource.onerror(e);
           expect(mockGetStore.dispatch).toHaveBeenCalledTimes(1);
           expect(mockGetStore.dispatch).toHaveBeenCalledWith({ type: SET_DISCONNECT_SSE, payload: {} });
         });
 
-        it("should retrieve the backoff duration", done => {
-          sse$
-            .errors(() => {})
-            .each(() => {
-              done.fail();
-            });
-
-          eventSource.close.mockImplementation(() => {
-            expect(backoff.duration).toHaveBeenCalledTimes(1);
-            done();
-          });
+        it("should retrieve the backoff duration", () => {
+          sse$.each(() => {});
 
           eventSource.onerror(e);
+          expect(backoff.duration).toHaveBeenCalledTimes(1);
         });
 
-        it("should close the stream after the duration", done => {
-          sse$
-            .errors(() => {})
-            .each(() => {
-              done.fail();
-            });
-
-          eventSource.close.mockImplementation(() => {
-            expect(eventSource.close).toHaveBeenCalledTimes(1);
-            done();
-          });
+        it("should close the stream", () => {
+          sse$.each(() => {});
 
           eventSource.onerror(e);
+          expect(eventSource.close).toHaveBeenCalledTimes(1);
         });
 
         ["onopen", "onerror", "onmessage"].forEach(fn => {
-          it(`should set ${fn} to null`, done => {
-            sse$
-              .errors(() => {})
-              .each(() => {
-                done.fail();
-              });
-
-            eventSource.close.mockImplementation(() => {
-              expect(eventSource[fn]).toBe(null);
-              done();
-            });
+          it(`should set ${fn} to null`, () => {
+            sse$.each(() => {});
 
             eventSource.onerror(e);
+            expect(eventSource[fn]).toBe(null);
           });
         });
       });


### PR DESCRIPTION
Testing backoff for server send events currently works when it receives 502's. However, if nginx is stopped or the
chroma manager is restarted, the retry count will skyrocket exponentially. This was due to the event stream being closed
inside the setTimeout. To fix this, the close was moved outside of the timeout and only "next" is called inside the
timeout to turn the generator.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>