### PR TITLE
Wait for SSE before loading the app

### DIFF
--- a/source/iml/app/app-resolves.js
+++ b/source/iml/app/app-resolves.js
@@ -3,8 +3,9 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-import { resolveStream } from "../promise-transforms.js";
+import { resolveStream, streamToPromise } from "../promise-transforms.js";
 import socketStream from "../socket/socket-stream.js";
+import getStore from "../store/get-store.js";
 import { CACHE_INITIAL_DATA } from "../environment.js";
 
 export function alertStream() {
@@ -29,3 +30,5 @@ export function appSessionFactory() {
 
   return CACHE_INITIAL_DATA.session;
 }
+
+export const sseResolves = () => streamToPromise(getStore.select("locks"));

--- a/source/iml/app/app-states.js
+++ b/source/iml/app/app-states.js
@@ -7,6 +7,7 @@
 
 import * as fp from "@iml/fp";
 import global from "../global.js";
+import { sseResolves } from "./app-resolves.js";
 
 export const appState = {
   name: "app",
@@ -101,6 +102,7 @@ export const appState = {
     alertStream: ["appAlertStream", (x: Function) => x()],
     notificationStream: ["appNotificationStream", (x: Function) => x()],
     session: ["appSession", fp.identity],
-    wasm: () => global.wasm_bindgen("/wasm-components/package_bg.wasm")
+    wasm: () => global.wasm_bindgen("/wasm-components/package_bg.wasm"),
+    sse: sseResolves
   }
 };

--- a/test/spec/iml/app/__snapshots__/app-states-test.js.snap
+++ b/test/spec/iml/app/__snapshots__/app-states-test.js.snap
@@ -19,6 +19,7 @@ Object {
       "appSession",
       [Function],
     ],
+    "sse": [MockFunction],
     "wasm": [Function],
   },
   "template": "<notification-slider stream=\\"app.alertStream\\"></notification-slider>

--- a/test/spec/iml/app/app-resolves-test.js
+++ b/test/spec/iml/app/app-resolves-test.js
@@ -1,31 +1,36 @@
+import highland from "highland";
+
 describe("app resolves", () => {
-  let mockSocketStream, mockResolveStream, promise, stream, appModule, mockCacheInitialData;
+  let mockSocketStream, promise, stream, locksStream, appModule, mockCacheInitialData, mockGetStore;
   beforeEach(() => {
     promise = {};
-    mockResolveStream = jest.fn();
-    mockResolveStream.mockReturnValue(promise);
-    stream = {};
+    stream = highland([promise]);
     mockSocketStream = jest.fn();
     mockSocketStream.mockReturnValue(stream);
     mockCacheInitialData = { session: {} };
-    appModule = jest.mock("../../../../source/iml/promise-transforms.js", () => ({
-      resolveStream: mockResolveStream
-    }));
+    locksStream = highland();
+    mockGetStore = {
+      select: jest.fn(() => locksStream)
+    };
     jest.mock("../../../../source/iml/socket/socket-stream.js", () => mockSocketStream);
     jest.mock("../../../../source/iml/environment.js", () => ({
       CACHE_INITIAL_DATA: mockCacheInitialData
     }));
+    jest.mock("../../../../source/iml/store/get-store.js", () => mockGetStore);
 
     appModule = require("../../../../source/iml/app/app-resolves.js");
   });
 
   describe("app alert stream", () => {
     let result;
-    beforeEach(() => {
-      result = appModule.alertStream();
+    beforeEach(async () => {
+      result = await appModule.alertStream();
     });
-    it("should return a promise", () => {
-      expect(result).toBe(promise);
+    it("should return a promise", done => {
+      result.each(x => {
+        expect(x).toBe(promise);
+        done();
+      });
     });
     it("should create a socket connection", () => {
       expect(mockSocketStream).toHaveBeenCalledOnceWith("/alert/", {
@@ -36,17 +41,17 @@ describe("app resolves", () => {
   });
   describe("app notification stream", () => {
     let result;
-    beforeEach(() => {
-      result = appModule.appNotificationStream();
+    beforeEach(async () => {
+      result = await appModule.appNotificationStream();
     });
-    it("should return a promise", () => {
-      expect(result).toBe(promise);
+    it("should return a promise", done => {
+      result.each(x => {
+        expect(x).toBe(promise);
+        done();
+      });
     });
     it("should create a socket connection", () => {
       expect(mockSocketStream).toHaveBeenCalledOnceWith("/health");
-    });
-    it("should call resolveStream with a stream", () => {
-      expect(mockResolveStream).toHaveBeenCalledOnceWith(stream);
     });
   });
   describe("app session", () => {
@@ -56,6 +61,17 @@ describe("app resolves", () => {
     });
     it("should return the session", () => {
       expect(appSession).toBe(mockCacheInitialData.session);
+    });
+  });
+
+  describe("sseResolves", () => {
+    beforeEach(() => {
+      locksStream.write({});
+    });
+
+    it("should return a Promise containing the lock information", async () => {
+      const locks = await appModule.sseResolves();
+      expect(locks).toEqual({});
     });
   });
 });

--- a/test/spec/iml/app/app-states-test.js
+++ b/test/spec/iml/app/app-states-test.js
@@ -1,5 +1,5 @@
 describe("app states", () => {
-  let spy, appState, mockGlobal;
+  let spy, appState, mockGlobal, mockAppResolves;
   beforeEach(() => {
     spy = jest.fn();
 
@@ -7,6 +7,11 @@ describe("app states", () => {
       wasm_bindgen: jest.fn()
     };
     jest.mock("../../../../source/iml/global.js", () => mockGlobal);
+
+    mockAppResolves = {
+      sseResolves: jest.fn()
+    };
+    jest.mock("../../../../source/iml/app/app-resolves.js", () => mockAppResolves);
 
     appState = require("../../../../source/iml/app/app-states.js").appState;
   });
@@ -28,5 +33,9 @@ describe("app states", () => {
 
     expect(mockGlobal.wasm_bindgen).toHaveBeenCalledTimes(1);
     expect(mockGlobal.wasm_bindgen).toHaveBeenCalledWith("/wasm-components/package_bg.wasm");
+  });
+
+  it("should have a sse resolve", () => {
+    expect(appState.resolve.sse).toBe(mockAppResolves.sseResolves);
   });
 });


### PR DESCRIPTION
The app should not load until data is received from the event stream. This patch will add a resolve on the sse to make
sure data is received from the store before the app is loaded.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>