### PR TITLE
Update logs to take raw html

### DIFF
--- a/iml-gui.spec
+++ b/iml-gui.spec
@@ -3,7 +3,7 @@
 %define backcompatdir /usr/lib%{managerdir}
 
 Name:       iml-%{base_name}
-Version:    6.5.1
+Version:    6.5.2
 # Release Start
 Release:    1%{?dist}
 # Release End

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/gui",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/gui",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "license": "MIT",
   "author": "IML Team",
   "scripts": {

--- a/source/iml/command/command-modal.js
+++ b/source/iml/command/command-modal.js
@@ -255,7 +255,7 @@ const CommandLogsComponent = ({ logs }) => {
   return (
     <div>
       <h4>Logs</h4>
-      <pre class="logs">{logs}</pre>
+      <pre class="logs" dangerouslySetInnerHTML={{ __html: logs }} />
     </div>
   );
 };

--- a/source/iml/command/step-modal.js
+++ b/source/iml/command/step-modal.js
@@ -54,7 +54,7 @@ const StepConsoleComponent = ({ step }) => {
     return (
       <div>
         <h4>Logs</h4>
-        <pre class="logs">{step.console}</pre>
+        <pre class="logs" dangerouslySetInnerHTML={{ __html: step.console }} />
       </div>
     );
   else return null;


### PR DESCRIPTION
The logs on the command window do not currently allow for raw html. This will allow html formatting within the log
window.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>