### PR TITLE
Pass Stragem configuration and server data into wasm components on fs detail page

### DIFF
--- a/flow-typed/window.js
+++ b/flow-typed/window.js
@@ -35,7 +35,7 @@ declare var window: {
   IS_RELEASE: boolean,
   dispatchEvent: Event => void,
   addEventListener: (evName: string, cb: (ev: Object) => any, useCapture?: boolean) => void,
-  removeEventListener: (evName: string, cb: (ev: Object) => any, useCapture: boolean) => void,
+  removeEventListener: (evName: string, cb: (ev: Object) => any, useCapture?: boolean) => void,
   ALLOW_ANONYMOUS_READ: boolean,
   SERVER_TIME_DIFF: number,
   VERSION: string,

--- a/source/iml/file-system/file-system-detail-component.js
+++ b/source/iml/file-system/file-system-detail-component.js
@@ -21,12 +21,20 @@ function Controller($element) {
       this.seedApp.set_targets(x);
     });
 
+    this.server$.each(x => {
+      this.seedApp.set_hosts(x);
+    });
+
     this.alertIndicator$.each(x => {
       this.seedApp.set_alerts(x);
     });
 
     this.locks$.each(x => {
       this.seedApp.set_locks(x);
+    });
+
+    this.stratagemConfiguration$.each(x => {
+      this.seedApp.set_stratagem_configuration(x);
     });
   };
 
@@ -38,8 +46,10 @@ function Controller($element) {
 
     this.fileSystem$.destroy();
     this.target$.destroy();
+    this.server$.destroy();
     this.alertIndicator$.destroy();
     this.locks$.destroy();
+    this.stratagemConfiguration$.destroy();
   };
 }
 
@@ -47,8 +57,10 @@ export default {
   bindings: {
     fileSystem$: "<",
     target$: "<",
+    server$: "<",
     alertIndicator$: "<",
-    locks$: "<"
+    locks$: "<",
+    stratagemConfiguration$: "<"
   },
   controller: Controller,
   template: `

--- a/source/iml/file-system/file-system-detail-resolves.js
+++ b/source/iml/file-system/file-system-detail-resolves.js
@@ -40,6 +40,17 @@ export const target$ = $stateParams => {
   );
 };
 
+export const server$ = () => store.select("server");
+
 export const locks$ = () => store.select("locks");
 
 export const alertIndicator$ = () => store.select("alertIndicators").map(Object.values);
+
+export const stratagemConfiguration$ = $stateParams => {
+  "ngInject";
+
+  return store
+    .select("stratagem")
+    .map(Object.values)
+    .map(xs => xs.find(x => x.filesystem_id === Number.parseInt($stateParams.id)));
+};

--- a/source/iml/file-system/file-system-states.js
+++ b/source/iml/file-system/file-system-states.js
@@ -4,7 +4,15 @@
 
 import store from "../store/get-store.js";
 import { GROUPS } from "../auth/authorization.js";
-import { getData, fileSystem$, target$, locks$, alertIndicator$ } from "./file-system-detail-resolves.js";
+import {
+  getData,
+  fileSystem$,
+  server$,
+  target$,
+  locks$,
+  alertIndicator$,
+  stratagemConfiguration$
+} from "./file-system-detail-resolves.js";
 
 export const fileSystemListState = {
   url: "/configure/filesystem",
@@ -60,7 +68,9 @@ export const fileSystemDetailState = {
     getData,
     fileSystem$,
     target$,
+    server$,
     locks$,
-    alertIndicator$
+    alertIndicator$,
+    stratagemConfiguration$
   }
 };

--- a/source/iml/store/get-store.js
+++ b/source/iml/store/get-store.js
@@ -36,6 +36,7 @@ import confirmActionReducer from "../action-dropdown/confirm-action-reducer.js";
 import commandModalReducer from "../command/command-modal-reducer.js";
 import stepModalReducer from "../command/step-modal-reducer.js";
 import modalStackReducer from "../modal-stack-reducer.js";
+import stratagemReducer from "../stratagem/stratagem-reducer.js";
 
 export default createStore({
   agentVsCopytoolCharts: agentVsCopytoolChartReducer,
@@ -66,5 +67,6 @@ export default createStore({
   confirmAction: confirmActionReducer,
   commandModal: commandModalReducer,
   stepModal: stepModalReducer,
-  modalStack: modalStackReducer
+  modalStack: modalStackReducer,
+  stratagem: stratagemReducer
 });

--- a/test/spec/iml/store/get-store-test.js
+++ b/test/spec/iml/store/get-store-test.js
@@ -30,7 +30,8 @@ describe("get store", () => {
     mockConfirmActionReducer,
     mockCommandModalReducer,
     mockStepModalReducer,
-    mockModalStackReducer;
+    mockModalStackReducer,
+    mockStratagemReducer;
 
   beforeEach(() => {
     store = { dispatch: jest.fn() };
@@ -64,6 +65,7 @@ describe("get store", () => {
     mockCommandModalReducer = {};
     mockStepModalReducer = {};
     mockModalStackReducer = {};
+    mockStratagemReducer = {};
 
     jest.mock(
       "../../../../source/iml/read-write-heat-map/read-write-heat-map-chart-reducer.js",
@@ -107,6 +109,7 @@ describe("get store", () => {
     jest.mock("../../../../source/iml/command/command-modal-reducer.js", () => mockCommandModalReducer);
     jest.mock("../../../../source/iml/command/step-modal-reducer.js", () => mockStepModalReducer);
     jest.mock("../../../../source/iml/modal-stack-reducer.js", () => mockModalStackReducer);
+    jest.mock("../../../../source/iml/stratagem/stratagem-reducer.js", () => mockStratagemReducer);
 
     const storeModule = require("../../../../source/iml/store/get-store.js");
     storeInstance = storeModule.default;
@@ -145,7 +148,8 @@ describe("get store", () => {
       confirmAction: mockConfirmActionReducer,
       commandModal: mockCommandModalReducer,
       stepModal: mockStepModalReducer,
-      modalStack: mockModalStackReducer
+      modalStack: mockModalStackReducer,
+      stratagem: mockStratagemReducer
     });
   });
 });


### PR DESCRIPTION
The fs detail page uses the new wasm components to render the gui. It is currently missing both the server data and the
stratagem configuration data. This information is streamed in from warp drive and passed into the wasm components.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>