### PR TITLE
Lower z-index of tooltip.

### DIFF
--- a/source/iml/tooltip/assets/css/tooltip.less
+++ b/source/iml/tooltip/assets/css/tooltip.less
@@ -3,7 +3,7 @@
 
   &.tooltip-hover:hover .tooltip.inferno-tt {
     display: block;
-    opacity: .9;
+    opacity: 0.9;
     max-width: 200px;
 
     .tooltip-inner {
@@ -15,12 +15,13 @@
 .has-error {
   > .tooltip.inferno-tt {
     display: block;
-    opacity: .9;
+    opacity: 0.9;
   }
 }
 
 .tooltip.inferno-tt {
   width: 200px;
+  z-index: 1050;
 
   &.xsmall {
     width: 50px;


### PR DESCRIPTION
So it does not overlay modals.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>