### PR TITLE
Enable / Update / Delete stratagem config should show command modal

### DIFF
--- a/source/iml/command/command-handlers.js
+++ b/source/iml/command/command-handlers.js
@@ -7,6 +7,7 @@ import socketStream from "../socket/socket-stream.js";
 import multiStream from "../multi-stream.js";
 import { setState, trimLogs } from "./command-transforms.js";
 
+import { closeCommandModal } from "../listeners.js";
 import { StepModalComponent } from "./step-modal.js";
 import { CommandModalComponent } from "./command-modal.js";
 import { querySelector } from "../dom-utils";
@@ -30,6 +31,8 @@ getStore.select("commandModal").each(([...commands]: Command[]) => {
       type: CLEAR_CONFIRM_ACTION,
       payload: false
     });
+
+    closeCommandModal();
   };
 
   command$

--- a/source/iml/file-system/file-system-detail-component.js
+++ b/source/iml/file-system/file-system-detail-component.js
@@ -9,7 +9,7 @@ function Controller($element) {
 
   const { render_fs_detail_page: renderFsDetailPage } = global.wasm_bindgen;
 
-  let onCloseCommandModal;
+  let onCommandModalClosed;
 
   this.$onInit = () => {
     const el = $element[0].querySelector(".mount-point");
@@ -42,11 +42,11 @@ function Controller($element) {
     // start fetching the inode table immediately
     this.seedApp.fetch_inode_table();
 
-    onCloseCommandModal = () => {
-      this.seedApp.close_command_modal();
+    onCommandModalClosed = () => {
+      this.seedApp.command_modal_closed();
     };
 
-    global.addEventListener("close_command_modal", onCloseCommandModal);
+    global.addEventListener("close_command_modal", onCommandModalClosed);
   };
 
   this.$onDestroy = () => {
@@ -62,7 +62,7 @@ function Controller($element) {
     this.locks$.destroy();
     this.stratagemConfiguration$.destroy();
 
-    global.removeEventListener("close_command_modal", onCloseCommandModal);
+    global.removeEventListener("close_command_modal", onCommandModalClosed);
   };
 }
 

--- a/source/iml/file-system/file-system-detail-component.js
+++ b/source/iml/file-system/file-system-detail-component.js
@@ -9,6 +9,8 @@ function Controller($element) {
 
   const { render_fs_detail_page: renderFsDetailPage } = global.wasm_bindgen;
 
+  let onCloseCommandModal;
+
   this.$onInit = () => {
     const el = $element[0].querySelector(".mount-point");
     this.seedApp = renderFsDetailPage(el);
@@ -39,6 +41,12 @@ function Controller($element) {
 
     // start fetching the inode table immediately
     this.seedApp.fetch_inode_table();
+
+    onCloseCommandModal = () => {
+      this.seedApp.close_command_modal();
+    };
+
+    global.addEventListener("close_command_modal", onCloseCommandModal);
   };
 
   this.$onDestroy = () => {
@@ -53,6 +61,8 @@ function Controller($element) {
     this.alertIndicator$.destroy();
     this.locks$.destroy();
     this.stratagemConfiguration$.destroy();
+
+    global.removeEventListener("close_command_modal", onCloseCommandModal);
   };
 }
 

--- a/source/iml/listeners.js
+++ b/source/iml/listeners.js
@@ -13,6 +13,10 @@ import {
   type RecordAndSelectedActionT,
   ACTION_DROPDOWN_FLAG_CHECK_DEPLOY
 } from "./action-dropdown/action-dropdown-types.js";
+import { SHOW_COMMAND_MODAL_ACTION } from "./command/command-modal-reducer.js";
+import getStore from "./store/get-store.js";
+
+import { type Command } from "./command/command-types.js";
 
 global.addEventListener(
   "action_selected",
@@ -44,6 +48,14 @@ global.addEventListener(
   }
 );
 
+global.addEventListener("show_command_modal", ({ detail: { command } }: { detail: { command: Command } }) => {
+  if (command != null)
+    getStore.dispatch({
+      type: SHOW_COMMAND_MODAL_ACTION,
+      payload: [command]
+    });
+});
+
 export const handleSelectedAction = (action: RecordAndSelectedActionT) => {
   const evt = new CustomEvent("action_selected", {
     detail: action
@@ -56,6 +68,12 @@ export const openAddServerModal = (record: RecordT, step: string) => {
   const evt = new CustomEvent("open_add_server_modal", {
     detail: { record, step }
   });
+
+  global.dispatchEvent(evt);
+};
+
+export const closeCommandModal = () => {
+  const evt = new CustomEvent("close_command_modal");
 
   global.dispatchEvent(evt);
 };


### PR DESCRIPTION
Fixes #1100.

Clicking the Enable / Update or Delete buttons within Stratagem config should show the command modal. This way the user can be notified of progress.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>