### PR TITLE
Available updates button disabled

### DIFF
--- a/source/iml/file-system/file-system-reducer.js
+++ b/source/iml/file-system/file-system-reducer.js
@@ -6,6 +6,33 @@ export const ADD_FS_ITEMS = "ADD_FS_ITEMS";
 export const DELETE_FILESYSTEM_ITEM = "DELETE_FILESYSTEM_ITEM";
 export const UPDATE_FILESYSTEM_ITEM = "UPDATE_FILESYSTEM_ITEM";
 
+import { type TargetT } from "../target/target-reducer.js";
+
+export type FilesystemT = {
+  bytes_free: Number,
+  bytes_total: Number,
+  cdt_mdt: String,
+  cdt_status: Option<String>,
+  client_count: Number,
+  conf_params: Option<Object>,
+  content_type_id: Number,
+  files_free: Number,
+  files_total: Number,
+  hsm_control_params: Object,
+  id: Number,
+  immutable_state: boolean,
+  label: String,
+  mdts: Array<TargetT>,
+  mgt: String,
+  mount_command: String,
+  mount_path: String,
+  name: String,
+  osts: Array<String>,
+  resource_uri: String,
+  state: String,
+  state_modified_at: String
+};
+
 import Immutable from "seamless-immutable";
 
 export default function(state = Immutable({}), { type, payload }) {

--- a/source/iml/server/server-controller.js
+++ b/source/iml/server/server-controller.js
@@ -5,11 +5,6 @@
 import { values } from "@iml/obj";
 import getStore from "../store/get-store.js";
 import global from "../global.js";
-import extractApi from "@iml/extract-api";
-import multiStream from "../multi-stream.js";
-
-import { type FilesystemT } from "../file-system/file-system-reducer.js";
-import { type TargetT } from "../target/target-reducer.js";
 
 import { SHOW_COMMAND_MODAL_ACTION } from "../command/command-modal-reducer.js";
 
@@ -188,30 +183,7 @@ export default function ServerCtrl(
     .map((xs: LockT) => ({ ...xs }))
     .through(p.bind(null, "locks"));
 
-  const getServers = (servers, filesystem: FilesystemT, targets: Array<TargetT>) =>
-    targets
-      .filter(
-        t =>
-          t.active_host != null &&
-          (t.filesystem_id === filesystem.id || t.filesystems.find(x => x.id === filesystem.id) != null)
-      )
-      .map(t => parseInt(extractApi(t.active_host), 10))
-      .filter(x => !isNaN(x))
-      .map(hostId => servers.find(h => h.id === hostId));
-
-  multiStream([streams.targetsStream, streams.fsStream])
-    .map(([targets, filesystems]) => {
-      const activeServers = filesystems
-        .filter(fs => fs.state === "available" || fs.state === "unavailable")
-        .map(fs => getServers($scope.server.servers, fs, targets))
-        .map(xs => new Set(xs))
-        .reduce((acc, curr) => {
-          return new Set([...acc, ...curr]);
-        }, new Set());
-
-      return [...activeServers].filter(x => x != null).map(x => x.id);
-    })
-    .through(p.bind(null, "activeServers"));
+  streams.activeServersStream.through(p.bind(null, "activeServers"));
 
   $scope.$on("$destroy", () => {
     values(streams).forEach(v => (v.destroy ? v.destroy() : v.endBroadcast()));

--- a/source/iml/server/server-reducer.js
+++ b/source/iml/server/server-reducer.js
@@ -8,6 +8,34 @@ export const ADD_SERVER_ITEMS = "ADD_SERVER_ITEMS";
 export const DELETE_SERVER_ITEM = "DELETE_SERVER_ITEM";
 export const UPDATE_SERVER_ITEM = "UPDATE_SERVER_ITEM";
 
+export type ServerT = {
+  address: String,
+  boot_time: String,
+  client_mounts: Array<String>,
+  content_type_id: Number,
+  corosync_configuration: String,
+  corosync_ring0: String,
+  fqdn: String,
+  id: Number,
+  immutable_state: Boolean,
+  install_method: String,
+  label: String,
+  lnet_configuration: String,
+  member_of_active_filesystem: Boolean,
+  needs_update: Boolean,
+  nids: Array<String>,
+  nodename: String,
+  pacemaker_configuration: String,
+  private_key: Option<String>,
+  private_key_passphrase: Option<String>,
+  properties: String,
+  resource_uri: String,
+  root_pw: Option<String>,
+  server_profile: Object,
+  state: String,
+  state_modified_at: String
+};
+
 export default function(state = Immutable({}), { type, payload }) {
   switch (type) {
     case ADD_SERVER_ITEMS:

--- a/source/iml/server/server-resolves.js
+++ b/source/iml/server/server-resolves.js
@@ -45,7 +45,6 @@ export default function serverResolves() {
       const activeServers = filesystems
         .filter(fs => fs.state === "available" || fs.state === "unavailable")
         .map(fs => getServers(servers, fs, targets))
-        .map(xs => new Set(xs))
         .reduce((acc, curr) => {
           return new Set([...acc, ...curr]);
         }, new Set());

--- a/source/iml/server/server-resolves.js
+++ b/source/iml/server/server-resolves.js
@@ -16,12 +16,23 @@ export default function serverResolves() {
 
   const serversStream = store.select("server").map(Object.values);
 
-  return Promise.all([locksStream, alertMonitorStream, lnetConfigurationStream, serversStream]).then(
-    ([locksStream, alertMonitorStream, lnetConfigurationStream, serversStream]) => ({
-      locksStream,
-      alertMonitorStream,
-      lnetConfigurationStream,
-      serversStream
-    })
-  );
+  const targetsStream = store.select("targets").map(Object.values);
+
+  const fsStream = store.select("fileSystems").map(Object.values);
+
+  return Promise.all([
+    locksStream,
+    alertMonitorStream,
+    lnetConfigurationStream,
+    serversStream,
+    targetsStream,
+    fsStream
+  ]).then(([locksStream, alertMonitorStream, lnetConfigurationStream, serversStream, targetsStream, fsStream]) => ({
+    locksStream,
+    alertMonitorStream,
+    lnetConfigurationStream,
+    serversStream,
+    targetsStream,
+    fsStream
+  }));
 }

--- a/source/iml/server/server-resolves.js
+++ b/source/iml/server/server-resolves.js
@@ -3,8 +3,14 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+import extractApi from "@iml/extract-api";
+
 import store from "../store/get-store.js";
 import broadcaster from "../broadcaster.js";
+import multiStream from "../multi-stream.js";
+
+import { type FilesystemT } from "../file-system/file-system-reducer.js";
+import { type TargetT } from "../target/target-reducer.js";
 
 export default function serverResolves() {
   "ngInject";
@@ -16,23 +22,49 @@ export default function serverResolves() {
 
   const serversStream = store.select("server").map(Object.values);
 
+  const serversStream2 = store.select("server").map(Object.values);
+
   const targetsStream = store.select("targets").map(Object.values);
 
   const fsStream = store.select("fileSystems").map(Object.values);
+
+  const getServers = (servers, filesystem: FilesystemT, targets: Array<TargetT>) =>
+    targets
+      .filter(
+        t =>
+          t.active_host != null &&
+          (t.filesystem_id === filesystem.id ||
+            (t.filesystems != null && t.filesystems.find(x => x.id === filesystem.id) != null))
+      )
+      .map(t => parseInt(extractApi(t.active_host), 10))
+      .filter(x => !isNaN(x))
+      .map(hostId => servers.find(h => h.id === hostId));
+
+  const activeServersStream = multiStream([serversStream2, targetsStream, fsStream]).map(
+    ([servers, targets, filesystems]) => {
+      const activeServers = filesystems
+        .filter(fs => fs.state === "available" || fs.state === "unavailable")
+        .map(fs => getServers(servers, fs, targets))
+        .map(xs => new Set(xs))
+        .reduce((acc, curr) => {
+          return new Set([...acc, ...curr]);
+        }, new Set());
+
+      return [...activeServers].filter(x => x != null).map(x => x.id);
+    }
+  );
 
   return Promise.all([
     locksStream,
     alertMonitorStream,
     lnetConfigurationStream,
     serversStream,
-    targetsStream,
-    fsStream
-  ]).then(([locksStream, alertMonitorStream, lnetConfigurationStream, serversStream, targetsStream, fsStream]) => ({
+    activeServersStream
+  ]).then(([locksStream, alertMonitorStream, lnetConfigurationStream, serversStream, activeServersStream]) => ({
     locksStream,
     alertMonitorStream,
     lnetConfigurationStream,
     serversStream,
-    targetsStream,
-    fsStream
+    activeServersStream
   }));
 }

--- a/source/iml/server/server-states.js
+++ b/source/iml/server/server-states.js
@@ -105,7 +105,7 @@ export const serverState = {
             <action-dropdown record="item" locks="server.locks" flag="check_deploy"></action-dropdown>
           </td>
           <td ng-if="server.editable" class="select-server">
-            <button ng-if="!server.getActionByValue(server.editName).toggleDisabled(item)"
+            <button ng-if="!server.getActionByValue(server.editName).toggleDisabled(item, server.activeServers)"
                     class="btn btn-info btn-sm"
                     ng-model="server.selectedServers[item.fqdn]"
                     uib-btn-checkbox>
@@ -116,12 +116,12 @@ export const serverState = {
                 Unselected
               </span>
             </button>
-            <span ng-if="server.getActionByValue(server.editName).toggleDisabled(item)"
+            <span ng-if="server.getActionByValue(server.editName).toggleDisabled(item, server.activeServers)"
               class="disabled tooltip-container tooltip-hover">
               <a type="button" class="disabled btn btn-default btn-sm">
                 Disabled
                 <iml-tooltip size="'large'" direction="left">
-                  <span>{{ server.getActionByValue(server.editName).toggleDisabledReason(item) }}</span>
+                  <span>{{ server.getActionByValue(server.editName).toggleDisabledReason(item, server.activeServers) }}</span>
                 </iml-tooltip>
               </a>
             </span>
@@ -174,12 +174,12 @@ export const serverState = {
     <div class="action-buttons">
       <span class="tooltip-container tooltip-hover" ng-repeat="action in server.actions track by action.value">
         <a type="button" class="btn btn-primary btn-sm"
-           ng-class="{disabled: action.buttonDisabled(server.servers)}"
+           ng-class="{disabled: action.buttonDisabled(server.servers, server.activeServers)}"
            ng-click="server.setEditName(action.value)">
           {{action.value}}
           <i class="fa fa-question-circle">
             <iml-tooltip size="'medium'" direction="top">
-              <span>{{ action.buttonTooltip(server.servers) }}</span>
+              <span>{{ action.buttonTooltip(server.servers, server.activeServers) }}</span>
             </iml-tooltip>
           </i>
         </a>

--- a/source/iml/target/target-reducer.js
+++ b/source/iml/target/target-reducer.js
@@ -8,6 +8,36 @@ export const ADD_TARGET_ITEMS = "ADD_TARGET_ITEMS";
 export const DELETE_TARGET_ITEM = "DELETE_TARGET_ITEM";
 export const UPDATE_TARGET_ITEM = "UPDATE_TARGET_ITEM";
 
+export type TargetT = {
+  active_host: String,
+  active_host_name: String,
+  conf_params: Option<Object>,
+  content_type_id: Number,
+  failover_server_name: String,
+  failover_servers: Array<String>,
+  filesystem: Option<String>,
+  filesystem_id: Option<Number>,
+  filesystem_name: Option<String>,
+  filesystems: Array<{ id: Number, name: String }>,
+  ha_label: String,
+  id: Number,
+  immutable_state: boolean,
+  index: Option<Number>,
+  inode_count: String,
+  inode_size: Number,
+  kind: String,
+  label: String,
+  name: String,
+  primary_server: String,
+  primary_server_name: String,
+  resource_uri: String,
+  state: String,
+  state_modified_at: String,
+  uuid: String,
+  volume: String,
+  volume_name: String
+};
+
 export default function targetReducer(state = Immutable({}), { type, payload }) {
   switch (type) {
     case ADD_TARGET_ITEMS:

--- a/test/spec/iml/server/server-controller-test.js
+++ b/test/spec/iml/server/server-controller-test.js
@@ -9,6 +9,7 @@ describe("server", () => {
     server,
     $uibModal,
     serversStream,
+    activeServersStream,
     selectedServers,
     serverActions,
     jobMonitorStream,
@@ -54,6 +55,9 @@ describe("server", () => {
 
       serversStream = highland();
       jest.spyOn(serversStream, "destroy");
+
+      activeServersStream = highland();
+      jest.spyOn(activeServersStream, "destroy");
 
       selectedServers = {
         servers: {},
@@ -111,7 +115,8 @@ describe("server", () => {
           jobMonitorStream,
           alertMonitorStream,
           lnetConfigurationStream,
-          locksStream
+          locksStream,
+          activeServersStream
         },
         openAddServerModal,
         localApply
@@ -417,6 +422,16 @@ describe("server", () => {
     });
   });
 
+  describe("activeServersStream data", () => {
+    beforeEach(() => {
+      activeServersStream.write([1, 2, 3, 4]);
+    });
+
+    it("should bind to the scope as data flows in", () => {
+      expect(server.activeServers).toEqual([1, 2, 3, 4]);
+    });
+  });
+
   describe("destroy", () => {
     beforeEach(() => {
       const handler = $scope.$on.mock.calls[0][1];
@@ -449,6 +464,10 @@ describe("server", () => {
 
     it("should destroy the locks stream", () => {
       expect(locks$.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("should destroy the activeServersStream", () => {
+      expect(activeServersStream.destroy).toHaveBeenCalledTimes(1);
     });
 
     it("should remopve the add server modal listener", () => {

--- a/test/spec/iml/server/server-resolves-test.js
+++ b/test/spec/iml/server/server-resolves-test.js
@@ -1,11 +1,12 @@
 import highland from "highland";
+import { streamToPromise } from "../../../../source/iml/promise-transforms.js";
 
 describe("server resolves", () => {
   let mockStore, serverResolves;
 
   beforeEach(() => {
     mockStore = {
-      select: jest.fn(() => highland())
+      select: jest.fn()
     };
 
     jest.mock("../../../../source/iml/store/get-store", () => mockStore);
@@ -23,6 +24,7 @@ describe("server resolves", () => {
     let promise;
 
     beforeEach(() => {
+      mockStore.select.mockImplementation(() => highland());
       promise = serverResolves();
     });
 
@@ -35,11 +37,19 @@ describe("server resolves", () => {
     });
 
     it("should create a servers stream", () => {
-      expect(mockStore.select).toHaveBeenCalledOnceWith("server");
+      expect(mockStore.select).toHaveBeenCalledWith("server");
     });
 
     it("should create a lnet configuration stream", () => {
       expect(mockStore.select).toHaveBeenCalledOnceWith("lnetConfiguration");
+    });
+
+    it("should create a targets stream", () => {
+      expect(mockStore.select).toHaveBeenCalledOnceWith("targets");
+    });
+
+    it("should create a filesystem stream", () => {
+      expect(mockStore.select).toHaveBeenCalledOnceWith("fileSystems");
     });
 
     it("should return an object of streams", async () => {
@@ -49,7 +59,338 @@ describe("server resolves", () => {
         locksStream: expect.any(Function),
         alertMonitorStream: expect.any(Function),
         lnetConfigurationStream: expect.any(Function),
-        serversStream: expect.any(Object)
+        serversStream: expect.any(Object),
+        activeServersStream: expect.any(Object)
+      });
+    });
+  });
+
+  describe("activeServerStream", () => {
+    let streams, servers, targets, filesystems;
+    beforeEach(() => {
+      servers = [
+        {
+          address: "mds1",
+          id: 1
+        },
+        {
+          address: "mds2",
+          id: 2
+        },
+        {
+          address: "oss1",
+          id: 3
+        },
+        {
+          address: "oss2",
+          id: 4
+        }
+      ];
+
+      targets = [
+        {
+          id: 1,
+          active_host: "/api/host/1/",
+          filesystems: [
+            {
+              id: 1,
+              name: "fs"
+            }
+          ],
+          filesystem_id: null
+        },
+        {
+          id: 2,
+          active_host: "/api/host/2/",
+          filesystems: null,
+          filesystem_id: 1
+        },
+        {
+          id: 3,
+          active_host: "/api/host/3/",
+          filesystems: null,
+          filesystem_id: 1
+        },
+        {
+          id: 4,
+          active_host: "/api/host/4/",
+          filesystems: null,
+          filesystem_id: 1
+        },
+        {
+          id: 5,
+          active_host: "/api/host/3/",
+          filesystems: null,
+          filesystem_id: 1
+        },
+        {
+          id: 6,
+          active_host: "/api/host/4/",
+          filesystems: null,
+          filesystem_id: 1
+        }
+      ];
+
+      filesystems = [
+        {
+          id: 1,
+          name: "fs",
+          state: "available"
+        }
+      ];
+    });
+
+    describe("with single filesystem", () => {
+      describe("having available state", () => {
+        it("should show all servers as being active", async () => {
+          mockStore.select.mockImplementation(key => {
+            if (key === "server") return highland([servers]);
+            else if (key === "targets") return highland([targets]);
+            else if (key === "fileSystems") return highland([filesystems]);
+            else return highland([]);
+          });
+
+          const mod = require("../../../../source/iml/server/server-resolves.js");
+
+          serverResolves = mod.default;
+
+          streams = await serverResolves();
+
+          const activeServers = await streamToPromise(streams.activeServersStream);
+          expect(activeServers).toEqual([1, 2, 3, 4]);
+        });
+      });
+
+      describe("having unavailable state", () => {
+        it("should show all servers as being active", async () => {
+          filesystems[0].state = "unavailable";
+          mockStore.select.mockImplementation(key => {
+            if (key === "server") return highland([servers]);
+            else if (key === "targets") return highland([targets]);
+            else if (key === "fileSystems") return highland([filesystems]);
+            else return highland([]);
+          });
+
+          const mod = require("../../../../source/iml/server/server-resolves.js");
+
+          serverResolves = mod.default;
+
+          streams = await serverResolves();
+
+          const activeServers = await streamToPromise(streams.activeServersStream);
+          expect(activeServers).toEqual([1, 2, 3, 4]);
+        });
+      });
+
+      describe("where filesystem is stopped", () => {
+        it("should not show any servers as being active", async () => {
+          filesystems[0].state = "stopped";
+          mockStore.select.mockImplementation(key => {
+            if (key === "server") return highland([servers]);
+            else if (key === "targets") return highland([targets]);
+            else if (key === "fileSystems") return highland([filesystems]);
+            else return highland([]);
+          });
+
+          const mod = require("../../../../source/iml/server/server-resolves.js");
+
+          serverResolves = mod.default;
+
+          streams = await serverResolves();
+
+          const activeServers = await streamToPromise(streams.activeServersStream);
+          expect(activeServers).toEqual([]);
+        });
+      });
+
+      describe("with an unmounted target", () => {
+        it("should show only active servers as being active", async () => {
+          targets[1].active_host = null;
+          mockStore.select.mockImplementation(key => {
+            if (key === "server") return highland([servers]);
+            else if (key === "targets") return highland([targets]);
+            else if (key === "fileSystems") return highland([filesystems]);
+            else return highland([]);
+          });
+
+          const mod = require("../../../../source/iml/server/server-resolves.js");
+
+          serverResolves = mod.default;
+
+          streams = await serverResolves();
+
+          const activeServers = await streamToPromise(streams.activeServersStream);
+          expect(activeServers).toEqual([1, 3, 4]);
+        });
+      });
+
+      describe("with a removed host", () => {
+        it("should show all servers as being active", async () => {
+          mockStore.select.mockImplementation(key => {
+            if (key === "server") return highland([[servers[0], servers[1], servers[3]]]);
+            else if (key === "targets") return highland([targets]);
+            else if (key === "fileSystems") return highland([filesystems]);
+            else return highland([]);
+          });
+
+          const mod = require("../../../../source/iml/server/server-resolves.js");
+
+          serverResolves = mod.default;
+
+          streams = await serverResolves();
+
+          const activeServers = await streamToPromise(streams.activeServersStream);
+          expect(activeServers).toEqual([1, 2, 4]);
+        });
+      });
+    });
+
+    describe("with multiple filesystems", () => {
+      beforeEach(() => {
+        filesystems = [
+          ...filesystems,
+          {
+            id: 2,
+            name: "fs2",
+            state: "available"
+          }
+        ];
+
+        targets[0].filesystems = [
+          ...targets[0].filesystems,
+          {
+            id: 2,
+            name: "fs2"
+          }
+        ];
+
+        targets = [
+          ...targets,
+          {
+            id: 7,
+            active_host: "/api/host/2/",
+            filesystems: null,
+            filesystem_id: 2
+          },
+          {
+            id: 8,
+            active_host: "/api/host/3/",
+            filesystems: null,
+            filesystem_id: 2
+          },
+          {
+            id: 9,
+            active_host: "/api/host/4/",
+            filesystems: null,
+            filesystem_id: 2
+          }
+        ];
+      });
+
+      describe("where both filesystems have available state", () => {
+        it("should show all servers as being active", async () => {
+          mockStore.select.mockImplementation(key => {
+            if (key === "server") return highland([servers]);
+            else if (key === "targets") return highland([targets]);
+            else if (key === "fileSystems") return highland([filesystems]);
+            else return highland([]);
+          });
+
+          const mod = require("../../../../source/iml/server/server-resolves.js");
+
+          serverResolves = mod.default;
+
+          streams = await serverResolves();
+
+          const activeServers = await streamToPromise(streams.activeServersStream);
+          expect(activeServers).toEqual([1, 2, 3, 4]);
+        });
+      });
+
+      describe("where one of the filesystems is stopped", () => {
+        it("should show all servers as being active", async () => {
+          filesystems[0].state = "stopped";
+          mockStore.select.mockImplementation(key => {
+            if (key === "server") return highland([servers]);
+            else if (key === "targets") return highland([targets]);
+            else if (key === "fileSystems") return highland([filesystems]);
+            else return highland([]);
+          });
+
+          const mod = require("../../../../source/iml/server/server-resolves.js");
+
+          serverResolves = mod.default;
+
+          streams = await serverResolves();
+
+          const activeServers = await streamToPromise(streams.activeServersStream);
+          expect(activeServers).toEqual([1, 2, 3, 4]);
+        });
+      });
+
+      describe("where both filesystems are stopped", () => {
+        it("should show no servers as being active", async () => {
+          filesystems = filesystems.map(x => {
+            x.state = "stopped";
+            return x;
+          });
+          mockStore.select.mockImplementation(key => {
+            if (key === "server") return highland([servers]);
+            else if (key === "targets") return highland([targets]);
+            else if (key === "fileSystems") return highland([filesystems]);
+            else return highland([]);
+          });
+
+          const mod = require("../../../../source/iml/server/server-resolves.js");
+
+          serverResolves = mod.default;
+
+          streams = await serverResolves();
+
+          const activeServers = await streamToPromise(streams.activeServersStream);
+          expect(activeServers).toEqual([]);
+        });
+      });
+
+      describe("with a server containing targets on fs2 that is not on fs1", () => {
+        fit("should show only the server associated with fs2 but not fs1 as being active", async () => {
+          filesystems[0].state = "stopped";
+          servers = [
+            ...servers,
+            {
+              id: 5,
+              address: "mds3"
+            },
+            {
+              id: 6,
+              address: "oss3"
+            }
+          ];
+
+          targets = targets.map(x => {
+            if (x.id === 7) x.active_host = "/api/host/5/";
+            else if (x.id === 8) x.active_host = "/api/host/6/";
+            else if (x.id === 9) x.active_host = "/api/host/6/";
+
+            return x;
+          });
+
+          mockStore.select.mockImplementation(key => {
+            if (key === "server") return highland([servers]);
+            else if (key === "targets") return highland([targets]);
+            else if (key === "fileSystems") return highland([filesystems]);
+            else return highland([]);
+          });
+
+          const mod = require("../../../../source/iml/server/server-resolves.js");
+
+          serverResolves = mod.default;
+
+          streams = await serverResolves();
+
+          const activeServers = await streamToPromise(streams.activeServersStream);
+          expect(activeServers).toEqual([1, 5, 6]);
+        });
       });
     });
   });

--- a/test/spec/iml/server/server-states-test.js
+++ b/test/spec/iml/server/server-states-test.js
@@ -123,7 +123,7 @@ describe("server states", () => {
             <action-dropdown record="item" locks="server.locks" flag="check_deploy"></action-dropdown>
           </td>
           <td ng-if="server.editable" class="select-server">
-            <button ng-if="!server.getActionByValue(server.editName).toggleDisabled(item)"
+            <button ng-if="!server.getActionByValue(server.editName).toggleDisabled(item, server.activeServers)"
                     class="btn btn-info btn-sm"
                     ng-model="server.selectedServers[item.fqdn]"
                     uib-btn-checkbox>
@@ -134,12 +134,12 @@ describe("server states", () => {
                 Unselected
               </span>
             </button>
-            <span ng-if="server.getActionByValue(server.editName).toggleDisabled(item)"
+            <span ng-if="server.getActionByValue(server.editName).toggleDisabled(item, server.activeServers)"
               class="disabled tooltip-container tooltip-hover">
               <a type="button" class="disabled btn btn-default btn-sm">
                 Disabled
                 <iml-tooltip size="'large'" direction="left">
-                  <span>{{ server.getActionByValue(server.editName).toggleDisabledReason(item) }}</span>
+                  <span>{{ server.getActionByValue(server.editName).toggleDisabledReason(item, server.activeServers) }}</span>
                 </iml-tooltip>
               </a>
             </span>
@@ -192,12 +192,12 @@ describe("server states", () => {
     <div class="action-buttons">
       <span class="tooltip-container tooltip-hover" ng-repeat="action in server.actions track by action.value">
         <a type="button" class="btn btn-primary btn-sm"
-           ng-class="{disabled: action.buttonDisabled(server.servers)}"
+           ng-class="{disabled: action.buttonDisabled(server.servers, server.activeServers)}"
            ng-click="server.setEditName(action.value)">
           {{action.value}}
           <i class="fa fa-question-circle">
             <iml-tooltip size="'medium'" direction="top">
-              <span>{{ action.buttonTooltip(server.servers) }}</span>
+              <span>{{ action.buttonTooltip(server.servers, server.activeServers) }}</span>
             </iml-tooltip>
           </i>
         </a>


### PR DESCRIPTION
Fixes #1237.

Description:
The available updates button remains disabled in an upgrade to 5.1. This is due to warp-drive not picking up changes for the computed property member_of_active_filesystem (which is derived mostly from the fs table). It seems like the most straightforward way to solve this is to check for server fs membership in the GUI by joining the data sets together.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>