### PR TITLE
GH-232 Selecting filesystem from dashboard dropdown causes error

### DIFF
--- a/source/iml/api-transforms.js
+++ b/source/iml/api-transforms.js
@@ -16,7 +16,11 @@ export function addCurrentPage<T: { meta: Object }>(o: T): T {
   };
 }
 
-export const matchById = (id: string) => fp.find(x => x.id === parseInt(id));
+export const matchById = (id: string) =>
+  fp.flow(
+    Object.values,
+    fp.find(x => x.id === parseInt(id))
+  );
 
 type MapFn<A, B> = A => B;
 export const rememberValue = <A, B, C: HighlandStreamT<B> | B[]>(mapFn: MapFn<A, C>) => (

--- a/source/iml/dashboard/base-dashboard-controller.js
+++ b/source/iml/dashboard/base-dashboard-controller.js
@@ -20,7 +20,8 @@ export default function BaseDashboardCtrl(
   $scope: $scopeT,
   fsB: Function,
   charts: Object[],
-  propagateChange: PropagateChange
+  propagateChange: PropagateChange,
+  $stateParams: { id?: String }
 ) {
   "ngInject";
   Object.assign(this, {
@@ -31,11 +32,14 @@ export default function BaseDashboardCtrl(
 
   fsB()
     .map(
-      fp.map(x => ({
-        ...x,
-        STATES,
-        state: x.immutable_state ? STATES.MONITORED : STATES.MANAGED
-      }))
+      fp.flow(
+        fp.filter(x => ($stateParams.id != null && x.id === parseInt($stateParams.id, 10)) || $stateParams.id == null),
+        fp.map(x => ({
+          ...x,
+          STATES,
+          state: x.immutable_state ? STATES.MONITORED : STATES.MANAGED
+        }))
+      )
     )
     .through(propagateChange.bind(null, $scope, this, "fs"));
 

--- a/source/iml/dashboard/dashboard-controller.js
+++ b/source/iml/dashboard/dashboard-controller.js
@@ -56,6 +56,7 @@ export default function DashboardCtrl(
 
         targetSelectStream = targetsB();
         targetSelectStream
+          .map(Object.values)
           .through(filterBy(item.selected.id))
           .map(fp.filter(x => x.kind !== "MGT"))
           .through(p.bind(null, "targets"));

--- a/test/spec/iml/api-transforms-test.js
+++ b/test/spec/iml/api-transforms-test.js
@@ -91,11 +91,23 @@ describe("api transforms", () => {
 });
 
 describe("match by id", () => {
-  it("should match by the id", () => {
-    const matcher = matchById(7);
-    expect(matcher([{ id: 1, name: "a" }, { id: 7, name: "b" }, { id: 10, name: "c" }])).toEqual(
-      of({ id: 7, name: "b" })
-    );
+  let data;
+  beforeEach(() => {
+    data = { 1: { id: 1, name: "a" }, 2: { id: 7, name: "b" }, 3: { id: 10, name: "c" } };
+  });
+
+  describe("given an array", () => {
+    it("should match by the id", () => {
+      const matcher = matchById(7);
+      expect(matcher(Object.values(data))).toEqual(of({ id: 7, name: "b" }));
+    });
+  });
+
+  describe("given an object", () => {
+    it("should match by the id", () => {
+      const matcher = matchById(7);
+      expect(matcher(data)).toEqual(of({ id: 7, name: "b" }));
+    });
   });
 });
 

--- a/test/spec/iml/dashboard/dashboard-controller-test.js
+++ b/test/spec/iml/dashboard/dashboard-controller-test.js
@@ -88,7 +88,7 @@ describe("dashboard controller", () => {
       expect(dashboard.targets).toBeNull();
     });
 
-    it("should set targets to ones matching the current fs", () => {
+    it("should set targets to ones matching the current fs given an array", () => {
       dashboard.fs.selected = {
         id: 5
       };
@@ -120,7 +120,39 @@ describe("dashboard controller", () => {
       ]);
     });
 
-    it("should set targets to ones matching the current host", () => {
+    it("should set targets to ones matching the current fs given an object", () => {
+      dashboard.fs.selected = {
+        id: 5
+      };
+
+      targetStream.write({
+        1: {
+          filesystems: [{ id: 5 }, { id: 6 }]
+        },
+        2: {
+          filesystems: [{ id: 6 }, { id: 7 }]
+        },
+        3: {
+          filesystem_id: 5
+        },
+        4: {
+          filesystem_id: 8
+        }
+      });
+
+      dashboard.itemChanged(dashboard.fs);
+
+      expect(dashboard.targets).toEqual([
+        {
+          filesystems: [{ id: 5 }, { id: 6 }]
+        },
+        {
+          filesystem_id: 5
+        }
+      ]);
+    });
+
+    it("should set targets to ones matching the current host given an array", () => {
       dashboard.host.selected = {
         id: "4"
       };
@@ -154,6 +186,41 @@ describe("dashboard controller", () => {
         }
       ]);
     });
+  });
+
+  it("should set targets to ones matching the current host given an object", () => {
+    dashboard.host.selected = {
+      id: "4"
+    };
+
+    dashboard.type = dashboard.host;
+
+    targetStream.write({
+      1: {
+        primary_server: "/api/host/3/",
+        failover_servers: ["/api/host/1/", "/api/host/4/"]
+      },
+      2: {
+        primary_server: "/api/host/4/",
+        failover_servers: ["/api/host/3/", "/api/host/2/"]
+      },
+      3: {
+        primary_server: "/api/host/7/"
+      }
+    });
+
+    dashboard.itemChanged(dashboard.host);
+
+    expect(dashboard.targets).toEqual([
+      {
+        primary_server: "/api/host/3/",
+        failover_servers: ["/api/host/1/", "/api/host/4/"]
+      },
+      {
+        primary_server: "/api/host/4/",
+        failover_servers: ["/api/host/3/", "/api/host/2/"]
+      }
+    ]);
   });
 
   it("should build a fs path", () => {

--- a/test/spec/iml/target/filter-target-by-fs-test.js
+++ b/test/spec/iml/target/filter-target-by-fs-test.js
@@ -5,36 +5,35 @@ describe("filter target by fs", () => {
   let data;
 
   beforeEach(() => {
-    data = [
-      [
-        {
-          target: "foo",
-          filesystems: [
-            {
-              id: 1
-            }
-          ]
-        },
-        {
-          target: "bar",
-          filesystems: [
-            {
-              id: 2
-            }
-          ]
-        },
-        {
-          target: "baz",
-          filesystem_id: 1
-        }
-      ]
-    ];
+    data = {
+      1: {
+        target: "foo",
+        filesystems: [
+          {
+            id: 1
+          }
+        ]
+      },
+      2: {
+        target: "bar",
+        filesystems: [
+          {
+            id: 2
+          }
+        ]
+      },
+      3: {
+        target: "baz",
+        filesystem_id: 1
+      }
+    };
   });
 
   it("should return the targets with the matching fs", function() {
     let result;
 
-    highland(data)
+    highland([data])
+      .map(Object.values)
       .through(filterTargetByFs(1))
       .each(function(x) {
         result = x;
@@ -57,7 +56,7 @@ describe("filter target by fs", () => {
   });
 
   it("should return nothing if id does not match", function() {
-    const result = filterTargetByFs("4")(data);
+    const result = filterTargetByFs("4")([Object.values(data)]);
 
     expect(result).toEqual([[]]);
   });


### PR DESCRIPTION
Fixes #232.

When selecting the filter on the dashboard page and selecting a filesystem the gui will crash. This happens because the
data format has changed from an array of objects to a hash in which each key points to an object. The data is
essentially the same, but in a different format. This caused the filter to blow up when selecting a filesystem,
            or applying a target. In addition, once the error was resolved, all filesystems were being displayed even
            though an individual one was selected. This happened because the dashboard controller was not filtering out
            filesystems based on the filesystem id that was selected. This patch resolves each of these problems.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>