### PR TITLE
Fix error when toggling update servers button

### DIFF
--- a/source/iml/server/server-controller.js
+++ b/source/iml/server/server-controller.js
@@ -110,7 +110,7 @@ export default function ServerCtrl(
         .filter(host => {
           if (!action.toggleDisabled) return true;
 
-          return !action.toggleDisabled(host);
+          return !action.toggleDisabled(host, $scope.server.activeServers);
         })
         .map(host => ({ ...host }));
     },


### PR DESCRIPTION
The active servers are not being passed into `toggleDisabled` when getting the selected hosts. Pass the active servers
when calling toggleDisabled.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>